### PR TITLE
Docker にプロンプトテンプレートのマウントを追加し要約機能を復旧

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN uv sync --no-dev --no-install-project
 
 # アプリケーションコードのコピー
 COPY app/ ./app/
+COPY prompts/ ./prompts/
 
 # 必要なディレクトリを作成し、実行ユーザー(1001)に権限を付与
 RUN mkdir -p data summaries db logs && chown -R 1001:1001 /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ./db:/app/db
       - ./logs:/app/logs
       - ./app:/app/app  # 開発時のホットリロード用
+      - ./prompts:/app/prompts  # プロンプトテンプレート
     user: "1001:1001"
     env_file:
       - .env


### PR DESCRIPTION
## Summary
- Dockerfile に `COPY prompts/ ./prompts/` を追加
- docker-compose.yml に `./prompts:/app/prompts` ボリュームマウントを追加
- PR #8（プロンプト外部化）以降、コンテナ内にテンプレートが存在せず 2026-03-22 以降の全記事の要約・日本語タイトル・タグ生成が失敗していた問題を修正

## Test plan
- [x] コンテナ再ビルド後、`/app/prompts/` にテンプレートが存在することを確認
- [x] パイプライン再実行で全カテゴリの要約が正常に生成されることを確認（CV 40件 全件 summarized）
- [x] ダイジェストが正しいフォーマットで生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)