### PR TITLE
モバイル時チャットパネルのスクロールロック・FAB制御を追加

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -20,11 +20,20 @@
         open: false,
         loaded: false,
         dateStr: '',
+        _updateBodyScroll(isOpen) {
+          // モバイル（lg未満）でチャットオープン時はbodyスクロールをロック
+          if (window.innerWidth < 1024 && isOpen) {
+            document.body.style.overflow = 'hidden';
+          } else {
+            document.body.style.overflow = '';
+          }
+        },
         toggle(dateStr) {
-          if (this.open) { this.open = false; return; }
+          if (this.open) { this.open = false; this._updateBodyScroll(false); return; }
           var needLoad = !this.loaded || this.dateStr !== dateStr;
           this.dateStr = dateStr;
           this.open = true;
+          this._updateBodyScroll(true);
           if (needLoad) {
             this.loaded = true;
             var url = '/daily-chat/' + dateStr + '/sessions/latest';
@@ -36,6 +45,17 @@
             if (mobile) htmx.ajax('GET', url, {target: '#daily-chat-panel-mobile', swap: 'innerHTML'});
           }
         }
+      });
+
+      // dailyChat.open の変更を監視してスクロールロックを同期（Escape等で閉じた場合にも対応）
+      Alpine.effect(() => {
+        var store = Alpine.store('dailyChat');
+        if (store) store._updateBodyScroll(store.open);
+      });
+      // リサイズ時にもスクロールロック状態を再評価
+      window.addEventListener('resize', () => {
+        var store = Alpine.store('dailyChat');
+        if (store) store._updateBodyScroll(store.open);
       });
     });
   </script>
@@ -511,10 +531,13 @@
 
   function updateFabs() {
     var scrolled = window.scrollY > 200;
-    btnTop.style.display = scrolled ? 'flex' : 'none';
 
     // チャットパネルが開いているか
     var chatOpen = window.Alpine && Alpine.store('dailyChat') && Alpine.store('dailyChat').open;
+    // モバイル（lg未満）でチャットが開いている場合はFABを全て非表示
+    var mobileChat = chatOpen && window.innerWidth < 1024;
+
+    btnTop.style.display = (scrolled && !mobileChat) ? 'flex' : 'none';
 
     // チャットFAB: スクロール済み + チャット未表示時のみ
     fabChat.style.display = (scrolled && !chatOpen) ? 'flex' : 'none';


### PR DESCRIPTION
## Summary
- モバイル（lg未満）でチャットパネルが開いている間、bodyスクロールをロックして背景のスクロールを防止
- チャットパネル閉鎖時・画面リサイズ時にもロック状態を適切に同期
- モバイルでチャットが開いている場合はFAB（トップへ戻る・チャット開閉）を非表示にしてUI干渉を防止

## Test plan
- [ ] モバイル幅（lg未満）でチャットパネルを開き、背景がスクロールしないことを確認
- [ ] チャットパネルを閉じた後、通常スクロールが復帰することを確認
- [ ] Escapeキー等でチャットを閉じた場合もスクロールロックが解除されることを確認
- [ ] 画面リサイズ（モバイル→デスクトップ）でスクロールロックが解除されることを確認
- [ ] デスクトップ幅ではスクロールロックが発動しないことを確認
- [ ] FABがモバイルチャットオープン時に非表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)