### PR TITLE
日毎チャットの送信表示バグとFABボタン不具合を修正

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -36,14 +36,23 @@
           this._updateBodyScroll(true);
           if (needLoad) {
             this.loaded = true;
-            var url = '/daily-chat/' + dateStr + '/sessions/latest';
-            // 広い画面用パネル
-            var desktop = document.getElementById('daily-chat-panel');
-            if (desktop) htmx.ajax('GET', url, {target: '#daily-chat-panel', swap: 'innerHTML'});
-            // 狭い画面用パネル
-            var mobile = document.getElementById('daily-chat-panel-mobile');
-            if (mobile) htmx.ajax('GET', url, {target: '#daily-chat-panel-mobile', swap: 'innerHTML'});
+            this._loadPanel(dateStr);
           }
+        },
+        _currentTarget: '',
+        _loadPanel(dateStr) {
+          var url = '/daily-chat/' + dateStr + '/sessions/latest';
+          // 画面幅に応じて片方のパネルのみにロード（重複IDによるHTMX swap誤動作を防止）
+          var isDesktop = window.innerWidth >= 1024;
+          var targetId = isDesktop ? '#daily-chat-panel' : '#daily-chat-panel-mobile';
+          var otherTarget = isDesktop ? document.getElementById('daily-chat-panel-mobile') : document.getElementById('daily-chat-panel');
+          // 以前ロードした側と異なる場合、古い方をクリアしてリロード
+          if (this._currentTarget && this._currentTarget !== targetId) {
+            if (otherTarget) otherTarget.innerHTML = '';
+          }
+          this._currentTarget = targetId;
+          var el = document.querySelector(targetId);
+          if (el) htmx.ajax('GET', url, {target: targetId, swap: 'innerHTML'});
         }
       });
 
@@ -52,10 +61,19 @@
         var store = Alpine.store('dailyChat');
         if (store) store._updateBodyScroll(store.open);
       });
-      // リサイズ時にもスクロールロック状態を再評価
+      // リサイズ時にスクロールロック状態を再評価し、必要に応じてパネルを再ロード
       window.addEventListener('resize', () => {
         var store = Alpine.store('dailyChat');
-        if (store) store._updateBodyScroll(store.open);
+        if (!store) return;
+        store._updateBodyScroll(store.open);
+        // 画面幅が変わりパネル切り替えが必要な場合、適切な側にリロード
+        if (store.open && store.loaded && store.dateStr) {
+          var isDesktop = window.innerWidth >= 1024;
+          var expectedTarget = isDesktop ? '#daily-chat-panel' : '#daily-chat-panel-mobile';
+          if (store._currentTarget !== expectedTarget) {
+            store._loadPanel(store.dateStr);
+          }
+        }
       });
     });
   </script>
@@ -524,8 +542,14 @@
   // チャットFABクリック: Alpine store のtoggleを呼ぶ
   fabChat.addEventListener('click', function() {
     if (window.Alpine && Alpine.store('dailyChat')) {
-      var dateStr = Alpine.store('dailyChat').dateStr;
-      if (dateStr) Alpine.store('dailyChat').toggle(dateStr);
+      var store = Alpine.store('dailyChat');
+      var dateStr = store.dateStr;
+      // dateStr が未設定の場合、ページの date_str を取得（data属性から）
+      if (!dateStr) {
+        var dateEl = document.querySelector('[data-page-date]');
+        if (dateEl) dateStr = dateEl.getAttribute('data-page-date');
+      }
+      if (dateStr) store.toggle(dateStr);
     }
   });
 

--- a/app/templates/pages/index.html
+++ b/app/templates/pages/index.html
@@ -2,6 +2,15 @@
 {% block title %}{{ date_str }} — AI Daily Survey{% endblock %}
 
 {% block content %}
+<!-- ページ日付データ（FABボタン等で使用） -->
+<div data-page-date="{{ date_str }}" style="display:none"></div>
+<!-- Alpine store に dateStr を初期設定 -->
+<script>
+document.addEventListener('alpine:initialized', function() {
+  var store = Alpine.store('dailyChat');
+  if (store && !store.dateStr) store.dateStr = '{{ date_str }}';
+});
+</script>
 <!-- ページヘッダー -->
 <div class="flex flex-col sm:flex-row sm:items-center justify-between mb-7 gap-3">
   <div>


### PR DESCRIPTION
## Summary
- 日毎チャットで送信したメッセージが画面に表示されないバグを修正（重複IDによるHTMX swap誤動作が原因）
- ページ下部のFABチャットボタンがモバイルで機能しない不具合を修正（dateStr未設定が原因）

## 原因と対策
### 送信表示バグ
- `toggle()` がデスクトップ・モバイル両パネルに同じHTMLをロードし、`daily-messages-{id}` が重複
- HTMXが非表示側のパネルにswapしていた
- **修正**: 画面幅に応じて片方のパネルのみにロード

### FABボタン不具合
- Alpine store の `dateStr` がページロード時に空文字のまま
- **修正**: `alpine:initialized` で初期設定 + `data-page-date` 属性からフォールバック

## Test plan
- [ ] モバイル幅で日毎チャットにメッセージ送信し、メッセージが表示されることを確認
- [ ] デスクトップ幅でも同様に確認
- [ ] ページ下部までスクロールしてFABチャットボタンをクリックし、チャットが開くことを確認
- [ ] 画面リサイズ時にチャットが正常に切り替わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)