### PR TITLE
チャットAI応答のマークダウンレンダリング対応

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,6 +13,8 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- HTMX -->
   <script src="https://unpkg.com/htmx.org@2.0.3"></script>
+  <!-- marked.js (Markdown レンダリング) -->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <!-- Alpine.js -->
   <script>
     document.addEventListener('alpine:init', () => {
@@ -91,6 +93,18 @@
     .prose a:hover { text-decoration-color: #2563eb; }
     .prose code { background: #f1f5f9; border: 1px solid #e2e8f0; border-radius: 4px; padding: 0.1em 0.35em; font-size: 0.85em; color: #475569; }
     .prose blockquote { border-left: 3px solid #c7d2fe; padding-left: 1rem; color: #6b7280; margin: 0.75rem 0; font-style: italic; }
+
+    /* チャットマークダウン（AI応答内の prose 微調整） */
+    .chat-markdown .prose { margin: 0; }
+    .chat-markdown .prose p { margin-bottom: 0.4rem; }
+    .chat-markdown .prose p:last-child { margin-bottom: 0; }
+    .chat-markdown .prose h1,
+    .chat-markdown .prose h2,
+    .chat-markdown .prose h3 { margin-top: 0.6rem; }
+    .chat-markdown .prose ul,
+    .chat-markdown .prose ol { margin: 0.3rem 0; }
+    .chat-markdown .prose pre { background: #1e293b; color: #e2e8f0; border-radius: 8px; padding: 0.75rem 1rem; overflow-x: auto; margin: 0.5rem 0; font-size: 0.8em; }
+    .chat-markdown .prose pre code { background: none; border: none; padding: 0; color: inherit; font-size: inherit; }
 
     /* チャット（記事カード内埋め込み用） */
     .card .chat-messages { max-height: 400px; overflow-y: auto; }

--- a/app/templates/components/chat/message_item.html
+++ b/app/templates/components/chat/message_item.html
@@ -10,16 +10,36 @@
       {% else %}
         bg-gray-100 text-gray-800
       {% endif %}">
-      {% if msg.role == 'assistant' and msg.used_search %}
-        {% set sources = msg.search_sources_parsed %}
-        {% set ns = namespace(content=msg.content | replace('\n', '<br>')) %}
-        {% for src in sources %}
-          {% set idx = loop.index %}
-          {% set badge = '[' ~ idx ~ ']' %}
-          {% set link = '<a href="' ~ src.uri ~ '" target="_blank" rel="noopener" class="inline-flex items-center justify-center w-4 h-4 text-[10px] font-bold text-blue-600 bg-blue-100 rounded hover:bg-blue-200 no-underline align-super leading-none" title="' ~ (src.title or src.uri) ~ '">' ~ idx ~ '</a>' %}
-          {% set ns.content = ns.content | replace(badge, link) %}
-        {% endfor %}
-        {{ ns.content | safe }}
+      {% if msg.role == 'assistant' %}
+        {% if msg.used_search %}
+          {% set sources = msg.search_sources_parsed %}
+          {# マークダウンレンダリング後に引用バッジを挿入 #}
+          <div class="prose prose-sm chat-markdown"
+               x-data x-init="
+                 var raw = $el.querySelector('.md-raw').textContent;
+                 var html = (typeof marked !== 'undefined') ? marked.parse(raw) : raw.replace(/\n/g, '<br>');
+                 {% for src in sources %}
+                   {% set idx = loop.index %}
+                   {% set badge = '[' ~ idx ~ ']' %}
+                   html = html.split('{{ badge }}').join('<a href=&quot;{{ src.uri }}&quot; target=&quot;_blank&quot; rel=&quot;noopener&quot; class=&quot;inline-flex items-center justify-center w-4 h-4 text-[10px] font-bold text-blue-600 bg-blue-100 rounded hover:bg-blue-200 no-underline align-super leading-none&quot; title=&quot;{{ (src.title or src.uri) | e }}&quot;>{{ idx }}</a>');
+                 {% endfor %}
+                 $el.querySelector('.md-render').innerHTML = html;
+               ">
+            <script type="text/plain" class="md-raw" style="display:none">{{ msg.content }}</script>
+            <div class="md-render"></div>
+          </div>
+        {% else %}
+          {# 検索なしのAI応答: マークダウンレンダリングのみ #}
+          <div class="prose prose-sm chat-markdown"
+               x-data x-init="
+                 var raw = $el.querySelector('.md-raw').textContent;
+                 var html = (typeof marked !== 'undefined') ? marked.parse(raw) : raw.replace(/\n/g, '<br>');
+                 $el.querySelector('.md-render').innerHTML = html;
+               ">
+            <script type="text/plain" class="md-raw" style="display:none">{{ msg.content }}</script>
+            <div class="md-render"></div>
+          </div>
+        {% endif %}
       {% else %}
         {{ msg.content | replace('\n', '<br>') | safe }}
       {% endif %}


### PR DESCRIPTION
## Summary
- AI応答をmarked.jsでマークダウンレンダリング（見出し、太字、リスト、コードブロック等）
- ユーザーメッセージは従来通りプレーンテキスト表示
- Web検索引用バッジはマークダウンレンダリング後に正しく挿入

## Test plan
- [ ] AI応答に太字・見出し・リスト・コードブロックが含まれる場合、正しくレンダリングされることを確認
- [ ] ユーザーメッセージが従来通り表示されることを確認
- [ ] Web検索を使用した応答で引用バッジが正しく表示されることを確認
- [ ] 記事チャット・日毎チャットの両方で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)