### PR TITLE
モバイルでのチャットボタン不具合を修正

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -89,8 +89,10 @@
     .prose strong { font-weight: 700; color: #111827; }
     .prose a { color: #2563eb; text-decoration: underline; text-decoration-color: #bfdbfe; text-underline-offset: 2px; transition: text-decoration-color 0.15s; }
     .prose a:hover { text-decoration-color: #2563eb; }
-    .prose code { background: #f1f5f9; border: 1px solid #e2e8f0; border-radius: 4px; padding: 0.1em 0.35em; font-size: 0.85em; color: #475569; }
+    .prose code { background: #f1f5f9; border: 1px solid #e2e8f0; border-radius: 4px; padding: 0.1em 0.35em; font-size: 0.85em; color: #475569; word-break: break-all; }
+    .prose pre { overflow-x: auto; max-width: 100%; }
     .prose blockquote { border-left: 3px solid #c7d2fe; padding-left: 1rem; color: #6b7280; margin: 0.75rem 0; font-style: italic; }
+    .prose img, .prose table { max-width: 100%; overflow-x: auto; display: block; }
 
     /* チャット（記事カード内埋め込み用） */
     .card .chat-messages { max-height: 400px; overflow-y: auto; }
@@ -111,9 +113,9 @@
       <span class="text-lg leading-none">📰</span>
       <span class="font-bold text-sm sm:text-base text-white tracking-tight group-hover:text-blue-300 transition-colors">AI Daily Survey</span>
     </a>
-    <nav class="flex items-center gap-1 text-sm">
+    <nav class="flex items-center gap-0.5 sm:gap-1 text-xs sm:text-sm">
       <a href="/"
-         class="px-3 py-1.5 rounded-lg font-medium transition-all duration-150
+         class="px-2 sm:px-3 py-1.5 rounded-lg font-medium transition-all duration-150
            {% if request.url.path == '/' or request.url.path.startswith('/archive') %}
              bg-white/15 text-white
            {% else %}
@@ -122,7 +124,7 @@
         今日
       </a>
       <a href="/summaries"
-         class="px-3 py-1.5 rounded-lg font-medium transition-all duration-150
+         class="px-2 sm:px-3 py-1.5 rounded-lg font-medium transition-all duration-150
            {% if request.url.path.startswith('/summaries') %}
              bg-white/15 text-white
            {% else %}
@@ -131,7 +133,7 @@
         まとめ
       </a>
       <a href="/tags"
-         class="px-3 py-1.5 rounded-lg font-medium transition-all duration-150
+         class="px-2 sm:px-3 py-1.5 rounded-lg font-medium transition-all duration-150
            {% if request.url.path.startswith('/tags') %}
              bg-white/15 text-white
            {% else %}
@@ -140,7 +142,7 @@
         タグ
       </a>
       <a href="/chat/search"
-         class="px-3 py-1.5 rounded-lg font-medium transition-all duration-150
+         class="px-2 sm:px-3 py-1.5 rounded-lg font-medium transition-all duration-150
            {% if request.url.path.startswith('/chat/search') %}
              bg-white/15 text-white
            {% else %}

--- a/app/templates/components/article/github_trending_section.html
+++ b/app/templates/components/article/github_trending_section.html
@@ -51,26 +51,26 @@
       </button>
 
       <!-- ソートトグル -->
-      <div class="inline-flex rounded-xl bg-gray-100 p-0.5 text-xs font-medium">
+      <div class="inline-flex flex-wrap rounded-xl bg-gray-100 p-0.5 text-xs font-medium">
         <button @click="sort='daily'"
                 :class="sort==='daily' ? 'bg-white shadow-sm text-emerald-700 ring-1 ring-emerald-200' : 'text-gray-500 hover:text-gray-700'"
-                class="px-2.5 sm:px-3.5 py-1.5 rounded-lg transition-all whitespace-nowrap">
-          Daily ★
+                class="px-2 sm:px-3.5 py-1.5 rounded-lg transition-all whitespace-nowrap">
+          D ★<span class="hidden sm:inline">aily</span>
         </button>
         <button @click="sort='weekly'"
                 :class="sort==='weekly' ? 'bg-white shadow-sm text-emerald-700 ring-1 ring-emerald-200' : 'text-gray-500 hover:text-gray-700'"
-                class="px-2.5 sm:px-3.5 py-1.5 rounded-lg transition-all whitespace-nowrap">
-          Weekly ★
+                class="px-2 sm:px-3.5 py-1.5 rounded-lg transition-all whitespace-nowrap">
+          W ★<span class="hidden sm:inline">eekly</span>
         </button>
         <button @click="sort='monthly'"
                 :class="sort==='monthly' ? 'bg-white shadow-sm text-emerald-700 ring-1 ring-emerald-200' : 'text-gray-500 hover:text-gray-700'"
-                class="px-2.5 sm:px-3.5 py-1.5 rounded-lg transition-all whitespace-nowrap">
-          Monthly ★
+                class="px-2 sm:px-3.5 py-1.5 rounded-lg transition-all whitespace-nowrap">
+          M ★<span class="hidden sm:inline">onthly</span>
         </button>
         <button @click="sort='total'"
                 :class="sort==='total' ? 'bg-white shadow-sm text-emerald-700 ring-1 ring-emerald-200' : 'text-gray-500 hover:text-gray-700'"
-                class="px-2.5 sm:px-3.5 py-1.5 rounded-lg transition-all whitespace-nowrap">
-          Total ★
+                class="px-2 sm:px-3.5 py-1.5 rounded-lg transition-all whitespace-nowrap">
+          T ★<span class="hidden sm:inline">otal</span>
         </button>
       </div>
     </div>

--- a/app/templates/components/chat/daily_panel.html
+++ b/app/templates/components/chat/daily_panel.html
@@ -91,6 +91,8 @@
             u.className = 'flex justify-end';
             u.innerHTML = '<div class=\'max-w-[85%]\'><div class=\'rounded-xl px-4 py-2 text-sm leading-relaxed bg-blue-600 text-white\'>' + userText.replace(/</g,'&lt;').replace(/\n/g,'<br>') + '</div></div>';
             msgs.appendChild(u);
+            ta.value = '';
+            ta.style.height = 'auto';
           }
           var t = document.createElement('div');
           t.id = 'daily-thinking-{{ session.id }}';

--- a/app/templates/components/chat/daily_panel.html
+++ b/app/templates/components/chat/daily_panel.html
@@ -11,12 +11,13 @@
 <div class="bg-blue-50 h-full flex flex-col" id="daily-chat-container">
 
   <!-- チャットヘッダー -->
-  <div class="px-3 py-2 bg-blue-600 text-white border-b border-blue-700 flex flex-wrap items-center justify-between gap-1 text-xs sm:text-sm shrink-0">
-    <div class="flex items-center gap-1 sm:gap-2 min-w-0">
+  <div class="px-3 py-2 bg-blue-600 text-white border-b border-blue-700 shrink-0 space-y-1.5">
+    <!-- 上段: 閉じる + 日付 + ナビ + タイトル -->
+    <div class="flex items-center gap-1.5 min-w-0 text-xs sm:text-sm">
       <button onclick="if(window.Alpine)Alpine.store('dailyChat').open=false"
               class="w-6 h-6 flex items-center justify-center rounded-full bg-blue-500 hover:bg-blue-400 text-white transition shrink-0 text-xs"
               title="チャットを閉じる">✕</button>
-      <span class="text-blue-100 shrink-0">{{ date_str }}</span>
+      <span class="text-blue-100 shrink-0 text-xs">{{ date_str }}</span>
 
       {% if current_index > 0 %}
       <button class="px-1.5 py-0.5 rounded border border-blue-400 bg-blue-500 hover:bg-blue-400 text-white shrink-0"
@@ -29,7 +30,7 @@
       <button class="px-1.5 py-0.5 rounded border border-blue-400 bg-blue-500 text-blue-300 cursor-not-allowed shrink-0" disabled>‹</button>
       {% endif %}
 
-      <span class="text-white font-medium truncate max-w-[120px] sm:max-w-48">{{ session.title }}</span>
+      <span class="text-white font-medium truncate min-w-0 flex-1">{{ session.title }}</span>
 
       {% if current_index < total_sessions - 1 %}
       <button class="px-1.5 py-0.5 rounded border border-blue-400 bg-blue-500 hover:bg-blue-400 text-white shrink-0"
@@ -44,8 +45,8 @@
 
       <span class="text-xs text-blue-200 shrink-0">{{ current_index + 1 }}/{{ total_sessions }}</span>
     </div>
-
-    <div class="flex items-center gap-1.5 shrink-0">
+    <!-- 下段: アクションボタン -->
+    <div class="flex items-center gap-1.5">
       <button class="flex items-center gap-1 text-xs bg-white text-blue-700 px-2.5 py-1 rounded-lg hover:bg-blue-50 transition font-medium"
               hx-post="/daily-chat/{{ date_str }}/sessions"
               hx-target="closest .daily-chat-target"

--- a/app/templates/components/chat/daily_panel.html
+++ b/app/templates/components/chat/daily_panel.html
@@ -21,7 +21,7 @@
       {% if current_index > 0 %}
       <button class="px-1.5 py-0.5 rounded border border-blue-400 bg-blue-500 hover:bg-blue-400 text-white shrink-0"
               hx-get="/daily-chat/{{ date_str }}/sessions/{{ all_sessions[current_index - 1].id }}"
-              hx-target="#daily-chat-panel"
+              hx-target="closest .daily-chat-target"
               hx-swap="innerHTML">
         ‹
       </button>
@@ -34,7 +34,7 @@
       {% if current_index < total_sessions - 1 %}
       <button class="px-1.5 py-0.5 rounded border border-blue-400 bg-blue-500 hover:bg-blue-400 text-white shrink-0"
               hx-get="/daily-chat/{{ date_str }}/sessions/{{ all_sessions[current_index + 1].id }}"
-              hx-target="#daily-chat-panel"
+              hx-target="closest .daily-chat-target"
               hx-swap="innerHTML">
         ›
       </button>
@@ -48,14 +48,14 @@
     <div class="flex items-center gap-1.5 shrink-0">
       <button class="flex items-center gap-1 text-xs bg-white text-blue-700 px-2.5 py-1 rounded-lg hover:bg-blue-50 transition font-medium"
               hx-post="/daily-chat/{{ date_str }}/sessions"
-              hx-target="#daily-chat-panel"
+              hx-target="closest .daily-chat-target"
               hx-swap="innerHTML">
         + 新規チャット
       </button>
       <button class="flex items-center gap-1 text-xs bg-blue-500 text-blue-100 border border-blue-400 px-2.5 py-1 rounded-lg hover:bg-blue-400 transition"
               hx-delete="/daily-chat/{{ date_str }}/sessions/{{ session.id }}"
               hx-confirm="このチャット「{{ session.title }}」を削除しますか？&#10;この操作は取り消せません。"
-              hx-target="#daily-chat-panel"
+              hx-target="closest .daily-chat-target"
               hx-swap="innerHTML">
         削除
       </button>

--- a/app/templates/components/chat/message_item.html
+++ b/app/templates/components/chat/message_item.html
@@ -3,8 +3,8 @@
   必要変数: msg (ChatMessage)
 -->
 <div class="flex {% if msg.role == 'user' %}justify-end{% else %}justify-start{% endif %}">
-  <div class="max-w-[85%]">
-    <div class="rounded-xl px-4 py-2 text-sm leading-relaxed
+  <div class="max-w-[85%] min-w-0 overflow-hidden">
+    <div class="rounded-xl px-3 sm:px-4 py-2 text-sm leading-relaxed break-words overflow-hidden
       {% if msg.role == 'user' %}
         bg-blue-600 text-white
       {% else %}

--- a/app/templates/components/chat/panel.html
+++ b/app/templates/components/chat/panel.html
@@ -90,6 +90,8 @@
             u.className = 'flex justify-end';
             u.innerHTML = '<div class=\'max-w-[85%]\'><div class=\'rounded-xl px-4 py-2 text-sm leading-relaxed bg-blue-600 text-white\'>' + userText.replace(/</g,'&lt;').replace(/\n/g,'<br>') + '</div></div>';
             msgs.appendChild(u);
+            ta.value = '';
+            ta.style.height = 'auto';
           }
           var t = document.createElement('div');
           t.id = 'thinking-{{ session.id }}';

--- a/app/templates/components/chat/panel.html
+++ b/app/templates/components/chat/panel.html
@@ -12,11 +12,11 @@
 <div class="bg-white" id="chat-container-{{ aid }}">
 
   <!-- チャットヘッダー（ナビゲーション） -->
-  <div class="px-3 py-2 bg-gray-50 border-b flex flex-wrap items-center justify-between gap-1 text-xs sm:text-sm">
-    <div class="flex items-center gap-1 sm:gap-2 min-w-0">
+  <div class="px-3 py-2 bg-gray-50 border-b space-y-1.5 text-xs sm:text-sm">
+    <!-- 上段: ナビゲーション -->
+    <div class="flex items-center gap-1.5 min-w-0">
       <span class="text-gray-500 shrink-0">チャット</span>
 
-      <!-- 前のチャットへ -->
       {% if current_index > 0 %}
       <button class="px-1.5 py-0.5 rounded border bg-white hover:bg-gray-100 text-gray-600 shrink-0"
               hx-get="/chat/{{ article.id }}/sessions/{{ all_sessions[current_index - 1].id }}"
@@ -28,9 +28,8 @@
       <button class="px-1.5 py-0.5 rounded border bg-white text-gray-300 cursor-not-allowed shrink-0" disabled>‹</button>
       {% endif %}
 
-      <span class="text-gray-700 font-medium truncate max-w-[100px] sm:max-w-40">{{ session.title }}</span>
+      <span class="text-gray-700 font-medium truncate min-w-0 flex-1">{{ session.title }}</span>
 
-      <!-- 次のチャットへ -->
       {% if current_index < total_sessions - 1 %}
       <button class="px-1.5 py-0.5 rounded border bg-white hover:bg-gray-100 text-gray-600 shrink-0"
               hx-get="/chat/{{ article.id }}/sessions/{{ all_sessions[current_index + 1].id }}"
@@ -44,18 +43,14 @@
 
       <span class="text-xs text-gray-400 shrink-0">{{ current_index + 1 }}/{{ total_sessions }}</span>
     </div>
-
-    <!-- 右側ボタン群 -->
-    <div class="flex items-center gap-1.5 shrink-0">
-      <!-- 新規チャット（常に有効。バックエンドで空セッション重複を防止） -->
+    <!-- 下段: アクションボタン -->
+    <div class="flex items-center gap-1.5">
       <button class="flex items-center gap-1 text-xs bg-emerald-600 text-white px-2.5 py-1 rounded-lg hover:bg-emerald-700 transition"
               hx-post="/chat/{{ article.id }}/sessions"
               hx-target="#chat-panel-{{ aid }}"
               hx-swap="innerHTML">
         ＋ 新規チャット
       </button>
-
-      <!-- チャット削除 -->
       <button class="flex items-center gap-1 text-xs bg-white text-red-500 border border-red-200 px-2.5 py-1 rounded-lg hover:bg-red-50 transition"
               hx-delete="/chat/{{ article.id }}/sessions/{{ session.id }}"
               hx-confirm="このチャット「{{ session.title }}」を削除しますか？&#10;この操作は取り消せません。"

--- a/app/templates/pages/index.html
+++ b/app/templates/pages/index.html
@@ -242,7 +242,7 @@
      :class="$store.dailyChat.open ? 'lg:w-[420px] lg:opacity-100' : 'lg:w-0 lg:opacity-0 lg:overflow-hidden'"
      class="hidden lg:flex flex-col shrink-0 bg-blue-50 border-l border-blue-200 sticky top-[52px] h-[calc(100vh-52px)] transition-all duration-300 ease-out">
   <!-- チャットコンテンツ（HTMX で差し替え） -->
-  <div id="daily-chat-panel" class="flex-1 flex flex-col overflow-hidden w-[420px]">
+  <div id="daily-chat-panel" class="daily-chat-target flex-1 flex flex-col overflow-hidden w-[420px]">
     <div class="flex items-center justify-center h-full text-blue-400 text-sm">
       <div class="flex items-center gap-2">
         <span class="inline-block w-4 h-4 border-2 border-blue-300 border-t-transparent rounded-full animate-spin"></span>
@@ -276,7 +276,7 @@
        x-transition:leave-end="translate-x-full"
        class="relative w-full max-w-md bg-blue-50 shadow-2xl border-l border-blue-200 flex flex-col h-full">
     <!-- モバイル用チャットコンテンツ（HTMX で差し替え） -->
-    <div id="daily-chat-panel-mobile" class="flex-1 flex flex-col overflow-hidden">
+    <div id="daily-chat-panel-mobile" class="daily-chat-target flex-1 flex flex-col overflow-hidden">
       <div class="flex items-center justify-center h-full text-blue-400 text-sm">
         <div class="flex items-center gap-2">
           <span class="inline-block w-4 h-4 border-2 border-blue-300 border-t-transparent rounded-full animate-spin"></span>


### PR DESCRIPTION
## Summary
- モバイル（lg未満）で「新規チャット」「削除」「前後ナビ」ボタンが機能しないバグを修正
- 原因: `daily_panel.html` の `hx-target` が `#daily-chat-panel` にハードコードされており、モバイル用パネル（`#daily-chat-panel-mobile`）では対象要素が見つからなかった
- 修正: 両パネルに共通クラス `.daily-chat-target` を付与し、`hx-target="closest .daily-chat-target"` で動的に親パネルを解決

## Test plan
- [ ] モバイル画面で「新規チャット」ボタンをタップ → 新しいセッションが作成されること
- [ ] モバイル画面でセッション切り替え（‹ ›）が動作すること
- [x] モバイル画面で「削除」ボタンが動作すること
- [ ] デスクトップ画面で既存動作に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)