### PR TITLE
#23 チャット送信UIのJS外部ファイル分離

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
 
 from app.config import settings
 from app.db.database import init_db, migrate_db
@@ -62,6 +63,9 @@ app.include_router(summaries.router)
 app.include_router(chat.router)
 app.include_router(daily_chat.router)
 app.include_router(user_tags.router)
+
+# 静的ファイル配信
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 
 # 手動実行エンドポイント（デバッグ・テスト用）

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -1,0 +1,111 @@
+/**
+ * チャット送信UI制御
+ * HTMX イベント委譲パターンで、動的に差し替わるフォームにも対応する。
+ * フォームに data-chat-form 属性があればチャットフォームとして扱う。
+ */
+(function () {
+  function isChatForm(form) {
+    return form && form.hasAttribute("data-chat-form");
+  }
+
+  document.body.addEventListener("htmx:beforeRequest", function (evt) {
+    var form = evt.detail.elt;
+    if (!isChatForm(form)) return;
+
+    var msgsId = form.getAttribute("data-messages-id");
+    var thinkingId = form.getAttribute("data-thinking-id");
+    var thinkingLabelId = form.getAttribute("data-thinking-label-id");
+    var submitBtnId = form.getAttribute("data-submit-btn-id");
+
+    var msgs = document.getElementById(msgsId);
+    if (!msgs) return;
+
+    // ユーザーメッセージ即時表示
+    var ta = form.querySelector("textarea");
+    var userText = ta ? ta.value.trim() : "";
+    if (userText) {
+      var u = document.createElement("div");
+      u.className = "flex justify-end";
+      u.innerHTML =
+        '<div class="max-w-[85%] min-w-0 overflow-hidden">' +
+        '<div class="rounded-xl px-3 sm:px-4 py-2 text-sm leading-relaxed break-words overflow-hidden bg-blue-600 text-white">' +
+        userText.replace(/</g, "&lt;").replace(/\n/g, "<br>") +
+        "</div></div>";
+      msgs.appendChild(u);
+      ta.value = "";
+      ta.style.height = "auto";
+    }
+
+    // 思考中スピナー
+    var t = document.createElement("div");
+    t.id = thinkingId;
+    t.className = "flex justify-start";
+    t.innerHTML =
+      '<div class="bg-gray-100 rounded-2xl px-4 py-2.5 text-sm text-gray-500">' +
+      '<div class="flex items-center gap-2">' +
+      '<span class="inline-block w-3.5 h-3.5 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"></span>' +
+      '<span id="' +
+      thinkingLabelId +
+      '">思考中...</span>' +
+      "</div></div>";
+    msgs.appendChild(t);
+    msgs.scrollTop = 9999;
+
+    // 3秒後に「Web検索中」に切り替え
+    form._searchTimer = setTimeout(function () {
+      var label = document.getElementById(thinkingLabelId);
+      if (!label) return;
+      label.closest(".bg-gray-100").innerHTML =
+        '<div class="flex items-center gap-2">' +
+        '<svg class="w-3.5 h-3.5 animate-spin text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">' +
+        '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>' +
+        "</svg>" +
+        '<span class="text-blue-600">Web検索中...</span>' +
+        "</div>" +
+        '<div class="mt-1 flex gap-1">' +
+        '<span class="inline-block w-1.5 h-1.5 bg-blue-400 rounded-full animate-bounce" style="animation-delay:0ms"></span>' +
+        '<span class="inline-block w-1.5 h-1.5 bg-blue-400 rounded-full animate-bounce" style="animation-delay:150ms"></span>' +
+        '<span class="inline-block w-1.5 h-1.5 bg-blue-400 rounded-full animate-bounce" style="animation-delay:300ms"></span>' +
+        "</div>";
+    }, 3000);
+
+    // ボタン無効化
+    var btn = document.getElementById(submitBtnId);
+    if (btn) {
+      btn.disabled = true;
+      btn.classList.add("opacity-40", "cursor-not-allowed");
+      btn.classList.remove("hover:bg-blue-700");
+    }
+  });
+
+  document.body.addEventListener("htmx:afterRequest", function (evt) {
+    var form = evt.detail.elt;
+    if (!isChatForm(form)) return;
+
+    var thinkingId = form.getAttribute("data-thinking-id");
+    var submitBtnId = form.getAttribute("data-submit-btn-id");
+    var msgsId = form.getAttribute("data-messages-id");
+
+    if (form._searchTimer) {
+      clearTimeout(form._searchTimer);
+      form._searchTimer = null;
+    }
+
+    var t = document.getElementById(thinkingId);
+    if (t) t.remove();
+
+    form.reset();
+    var ta = form.querySelector("textarea");
+    if (ta) ta.style.height = "auto";
+
+    var btn = document.getElementById(submitBtnId);
+    if (btn) {
+      btn.disabled = false;
+      btn.classList.remove("opacity-40", "cursor-not-allowed");
+      btn.classList.add("hover:bg-blue-700");
+    }
+
+    var msgs = document.getElementById(msgsId);
+    if (msgs) msgs.scrollTop = 9999;
+  });
+})();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -564,5 +564,6 @@
 }());
 </script>
 
+<script src="/static/js/chat.js"></script>
 </body>
 </html>

--- a/app/templates/components/chat/daily_panel.html
+++ b/app/templates/components/chat/daily_panel.html
@@ -82,63 +82,11 @@
         hx-post="/daily-chat/{{ date_str }}/sessions/{{ session.id }}/messages"
         hx-target="#daily-messages-{{ session.id }}"
         hx-swap="beforeend"
-        hx-on::before-request="
-          var msgs = document.getElementById('daily-messages-{{ session.id }}');
-          var ta = this.querySelector('textarea');
-          var userText = ta ? ta.value.trim() : '';
-          if (userText) {
-            var u = document.createElement('div');
-            u.className = 'flex justify-end';
-            u.innerHTML = '<div class=\'max-w-[85%]\'><div class=\'rounded-xl px-4 py-2 text-sm leading-relaxed bg-blue-600 text-white\'>' + userText.replace(/</g,'&lt;').replace(/\n/g,'<br>') + '</div></div>';
-            msgs.appendChild(u);
-            ta.value = '';
-            ta.style.height = 'auto';
-          }
-          var t = document.createElement('div');
-          t.id = 'daily-thinking-{{ session.id }}';
-          t.className = 'flex justify-start';
-          t.innerHTML = `<div class='bg-gray-100 rounded-2xl px-4 py-2.5 text-sm text-gray-500'>
-            <div class='flex items-center gap-2'>
-              <span class='inline-block w-3.5 h-3.5 border-2 border-gray-400 border-t-transparent rounded-full animate-spin'></span>
-              <span id='daily-thinking-label-{{ session.id }}'>思考中...</span>
-            </div>
-          </div>`;
-          msgs.appendChild(t);
-          msgs.scrollTop = 9999;
-          this._searchTimer = setTimeout(function(){
-            var label = document.getElementById('daily-thinking-label-{{ session.id }}');
-            if (!label) return;
-            label.closest('.bg-gray-100').innerHTML = `
-              <div class='flex items-center gap-2'>
-                <svg class='w-3.5 h-3.5 animate-spin text-blue-500' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                  <path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z'/>
-                </svg>
-                <span class='text-blue-600'>Web検索中...</span>
-              </div>
-              <div class='mt-1 flex gap-1'>
-                <span class='inline-block w-1.5 h-1.5 bg-blue-400 rounded-full animate-bounce' style='animation-delay:0ms'></span>
-                <span class='inline-block w-1.5 h-1.5 bg-blue-400 rounded-full animate-bounce' style='animation-delay:150ms'></span>
-                <span class='inline-block w-1.5 h-1.5 bg-blue-400 rounded-full animate-bounce' style='animation-delay:300ms'></span>
-              </div>`;
-          }, 3000);
-          var btn = document.getElementById('daily-chat-submit-{{ session.id }}');
-          btn.disabled = true;
-          btn.classList.add('opacity-40', 'cursor-not-allowed');
-          btn.classList.remove('hover:bg-blue-700');
-        "
-        hx-on::after-request="
-          if (this._searchTimer) { clearTimeout(this._searchTimer); this._searchTimer = null; }
-          var t = document.getElementById('daily-thinking-{{ session.id }}');
-          if (t) t.remove();
-          this.reset();
-          var ta = this.querySelector('textarea');
-          if (ta) ta.style.height = 'auto';
-          var btn = document.getElementById('daily-chat-submit-{{ session.id }}');
-          btn.disabled = false;
-          btn.classList.remove('opacity-40', 'cursor-not-allowed');
-          btn.classList.add('hover:bg-blue-700');
-          document.getElementById('daily-messages-{{ session.id }}').scrollTop = 9999;
-        ">
+        data-chat-form
+        data-messages-id="daily-messages-{{ session.id }}"
+        data-thinking-id="daily-thinking-{{ session.id }}"
+        data-thinking-label-id="daily-thinking-label-{{ session.id }}"
+        data-submit-btn-id="daily-chat-submit-{{ session.id }}">
     <textarea name="message" required rows="1"
               placeholder="今日の記事について質問… (Ctrl+Enter で送信)"
               class="flex-1 border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 resize-none overflow-hidden"

--- a/app/templates/components/chat/panel.html
+++ b/app/templates/components/chat/panel.html
@@ -81,63 +81,11 @@
         hx-post="/chat/{{ article.id }}/sessions/{{ session.id }}/messages"
         hx-target="#messages-{{ session.id }}"
         hx-swap="beforeend"
-        hx-on::before-request="
-          var msgs = document.getElementById('messages-{{ session.id }}');
-          var ta = this.querySelector('textarea');
-          var userText = ta ? ta.value.trim() : '';
-          if (userText) {
-            var u = document.createElement('div');
-            u.className = 'flex justify-end';
-            u.innerHTML = '<div class=\'max-w-[85%]\'><div class=\'rounded-xl px-4 py-2 text-sm leading-relaxed bg-blue-600 text-white\'>' + userText.replace(/</g,'&lt;').replace(/\n/g,'<br>') + '</div></div>';
-            msgs.appendChild(u);
-            ta.value = '';
-            ta.style.height = 'auto';
-          }
-          var t = document.createElement('div');
-          t.id = 'thinking-{{ session.id }}';
-          t.className = 'flex justify-start';
-          t.innerHTML = `<div class='bg-gray-100 rounded-2xl px-4 py-2.5 text-sm text-gray-500'>
-            <div class='flex items-center gap-2'>
-              <span class='inline-block w-3.5 h-3.5 border-2 border-gray-400 border-t-transparent rounded-full animate-spin'></span>
-              <span id='thinking-label-{{ session.id }}'>思考中...</span>
-            </div>
-          </div>`;
-          msgs.appendChild(t);
-          msgs.scrollTop = 9999;
-          this._searchTimer = setTimeout(function(){
-            var label = document.getElementById('thinking-label-{{ session.id }}');
-            if (!label) return;
-            label.closest('.bg-gray-100').innerHTML = `
-              <div class='flex items-center gap-2'>
-                <svg class='w-3.5 h-3.5 animate-spin text-blue-500' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                  <path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z'/>
-                </svg>
-                <span class='text-blue-600'>Web検索中...</span>
-              </div>
-              <div class='mt-1 flex gap-1'>
-                <span class='inline-block w-1.5 h-1.5 bg-blue-400 rounded-full animate-bounce' style='animation-delay:0ms'></span>
-                <span class='inline-block w-1.5 h-1.5 bg-blue-400 rounded-full animate-bounce' style='animation-delay:150ms'></span>
-                <span class='inline-block w-1.5 h-1.5 bg-blue-400 rounded-full animate-bounce' style='animation-delay:300ms'></span>
-              </div>`;
-          }, 3000);
-          var btn = document.getElementById('chat-submit-{{ session.id }}');
-          btn.disabled = true;
-          btn.classList.add('opacity-40', 'cursor-not-allowed');
-          btn.classList.remove('hover:bg-blue-700');
-        "
-        hx-on::after-request="
-          if (this._searchTimer) { clearTimeout(this._searchTimer); this._searchTimer = null; }
-          var t = document.getElementById('thinking-{{ session.id }}');
-          if (t) t.remove();
-          this.reset();
-          var ta = this.querySelector('textarea');
-          if (ta) ta.style.height = 'auto';
-          var btn = document.getElementById('chat-submit-{{ session.id }}');
-          btn.disabled = false;
-          btn.classList.remove('opacity-40', 'cursor-not-allowed');
-          btn.classList.add('hover:bg-blue-700');
-          document.getElementById('messages-{{ session.id }}').scrollTop = 9999;
-        ">
+        data-chat-form
+        data-messages-id="messages-{{ session.id }}"
+        data-thinking-id="thinking-{{ session.id }}"
+        data-thinking-label-id="thinking-label-{{ session.id }}"
+        data-submit-btn-id="chat-submit-{{ session.id }}">
     <textarea name="message" required rows="1"
               placeholder="質問を入力… (Ctrl+Enter で送信)"
               class="flex-1 border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 resize-none overflow-hidden"


### PR DESCRIPTION
## Summary
- チャット送信時のUI制御（ユーザーメッセージ即時表示、思考中スピナー、textarea クリア、ボタン制御）を `app/static/js/chat.js` に外部化
- `hx-on::before-request` / `hx-on::after-request` のインライン JS を削除し、HTMX イベント委譲パターン（`document.body` で `htmx:beforeRequest` / `htmx:afterRequest` をリッスン）に移行
- テンプレートのフォームは `data-chat-form` + `data-*` 属性で ID を渡すだけに簡素化
- FastAPI に `StaticFiles` マウントを追加

## なぜこれで安定するか
- `hx-on::*` インライン属性は HTMX が内部パース・実行するため、DOM 差し替え時に属性喪失・再パースリスクがあった
- `document.body` のイベントリスナーはページライフサイクルを通じて永続し、HTMX による DOM 差し替え後も確実に動作する
- 新規セッション作成で差し替わったフォームにも `data-chat-form` 属性で自動対応

Closes #23

## Test plan
- [ ] 日毎チャットで初回送信時にユーザーメッセージが即座に表示されること
- [ ] テキストエリアが送信直後にクリアされること
- [ ] 思考中スピナー → 3秒後にWeb検索中に切り替わること
- [ ] AI応答後にスピナーが消え、ボタンが再有効化されること
- [ ] 記事チャットでも同様に動作すること
- [ ] 新規チャット作成後の送信でも正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)