### PR TITLE
GitHub Trendingソートボタンのラベル表記を改善

### DIFF
--- a/app/templates/components/article/github_trending_section.html
+++ b/app/templates/components/article/github_trending_section.html
@@ -55,22 +55,22 @@
         <button @click="sort='daily'"
                 :class="sort==='daily' ? 'bg-white shadow-sm text-emerald-700 ring-1 ring-emerald-200' : 'text-gray-500 hover:text-gray-700'"
                 class="px-2 sm:px-3.5 py-1.5 rounded-lg transition-all whitespace-nowrap">
-          D ★<span class="hidden sm:inline">aily</span>
+          ⭐️D<span class="hidden sm:inline">aily</span>
         </button>
         <button @click="sort='weekly'"
                 :class="sort==='weekly' ? 'bg-white shadow-sm text-emerald-700 ring-1 ring-emerald-200' : 'text-gray-500 hover:text-gray-700'"
                 class="px-2 sm:px-3.5 py-1.5 rounded-lg transition-all whitespace-nowrap">
-          W ★<span class="hidden sm:inline">eekly</span>
+          ⭐️W<span class="hidden sm:inline">eekly</span>
         </button>
         <button @click="sort='monthly'"
                 :class="sort==='monthly' ? 'bg-white shadow-sm text-emerald-700 ring-1 ring-emerald-200' : 'text-gray-500 hover:text-gray-700'"
                 class="px-2 sm:px-3.5 py-1.5 rounded-lg transition-all whitespace-nowrap">
-          M ★<span class="hidden sm:inline">onthly</span>
+          ⭐️M<span class="hidden sm:inline">onthly</span>
         </button>
         <button @click="sort='total'"
                 :class="sort==='total' ? 'bg-white shadow-sm text-emerald-700 ring-1 ring-emerald-200' : 'text-gray-500 hover:text-gray-700'"
                 class="px-2 sm:px-3.5 py-1.5 rounded-lg transition-all whitespace-nowrap">
-          T ★<span class="hidden sm:inline">otal</span>
+          ⭐️T<span class="hidden sm:inline">otal</span>
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- GitHub Trendingセクションのソートボタンラベルを `D ★aily` 等の分割表記から `⭐️Daily` 等の自然な表記に変更
- モバイルでは `⭐️D` / `⭐️W` / `⭐️M` / `⭐️T` と表示

## Test plan
- [x] ブラウザでGitHub Trendingセクションのソートボタン表示を確認
- [x] モバイル幅でのレスポンシブ表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)