### PR TITLE
#30 refリンクのページ内スクロールを修正

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -469,11 +469,17 @@
     });
     stickyOffset += sectionStack.length >= 2 ? 40 : 8; // サブあり: 大きめ余白、なし: 小さめ
 
-    var delay = ancestors.length > 0 ? 260 : 50;
-    setTimeout(function () {
-      var top = target.getBoundingClientRect().top + window.scrollY - stickyOffset;
-      window.scrollTo({ top: top, behavior: 'smooth' });
-    }, delay);
+    // 要素が表示されるまで待ってからスクロール（x-show トランジション完了を待つ）
+    var maxWait = 2000;
+    var start = Date.now();
+    (function waitAndScroll() {
+      if (target.offsetHeight > 0) {
+        var top = target.getBoundingClientRect().top + window.scrollY - stickyOffset;
+        window.scrollTo({ top: top, behavior: 'smooth' });
+      } else if (Date.now() - start < maxWait) {
+        requestAnimationFrame(waitAndScroll);
+      }
+    })();
   }
 
   document.addEventListener('alpine:initialized', function () {


### PR DESCRIPTION
## Summary
- 一面まとめのrefリンククリック時に下にスクロールせず上に少し戻ってしまうバグを修正
- 原因: セクションが `x-show` で非表示の間、`getBoundingClientRect()` が `0` を返すため、固定遅延(260ms)ではトランジション完了前に位置計算していた
- 修正: 固定遅延の代わりに `requestAnimationFrame` で要素の `offsetHeight > 0` をポーリングし、表示完了後にスクロール

Closes #30

## Test plan
- [ ] 一面まとめ内のrefリンク(↗)をクリックし、対応する記事カードまで正しくスクロールすること
- [ ] ネストしたセクション（CV論文 > OpenReview等）内の記事へも正しくスクロールすること
- [ ] ページロード時に `#article-xxx` ハッシュ付きURLでアクセスした場合も正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)