### PR TITLE
#32 #33 チャット関連の不具合修正

### DIFF
--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -407,12 +407,13 @@ def _extract_grounding_info(response) -> tuple[bool, list[dict], str]:
         - sources: [{"title": str, "uri": str}, ...]
         - cited_text: インライン引用 [1][2] を埋め込んだテキスト
     """
+    text = response.text or ""
     try:
         meta = response.candidates[0].grounding_metadata
         if not meta or not meta.grounding_chunks:
-            return False, [], response.text
+            return False, [], text
     except (AttributeError, IndexError):
-        return False, [], response.text
+        return False, [], text
 
     # ソース一覧を構築
     sources: list[dict] = []
@@ -422,10 +423,9 @@ def _extract_grounding_info(response) -> tuple[bool, list[dict], str]:
             sources.append({"title": web.title or "", "uri": web.uri or ""})
 
     if not sources:
-        return False, [], response.text
+        return False, [], text
 
     # grounding_supports からインライン引用を挿入
-    text = response.text
     supports = meta.grounding_supports or []
     if supports:
         # end_index 降順でソート（後ろから挿入して位置ズレを防ぐ）

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -327,7 +327,9 @@ async def _get_or_create_article(article_id: str, db: AsyncSession) -> Article |
         "ai",
         "cl",
         "industry",
+        "industry_news",
         "community",
+        "github_trending",
         "python",
     ]
     for date_str in list_available_dates():

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -205,19 +205,22 @@ async def send_message(
     db.add(ai_msg)
 
     # 初回メッセージのときセッションタイトルを自動生成
+    new_title = None
     if len(chat_session.messages) == 0:
-        chat_session.title = await _generate_title(message)
+        new_title = await _generate_title(message)
+        chat_session.title = new_title
 
     await db.commit()
 
     # 新しいメッセージのみ HTML で返す（HTMX append）
-    return templates.TemplateResponse(
-        "components/chat/messages.html",
-        {
-            "request": request,
-            "messages": [ai_msg],
-        },
-    )
+    ctx: dict = {
+        "request": request,
+        "messages": [ai_msg],
+    }
+    if new_title:
+        ctx["new_title"] = new_title
+        ctx["title_element_id"] = f"chat-title-{session_id}"
+    return templates.TemplateResponse("components/chat/messages.html", ctx)
 
 
 # ── セッション削除 ──────────────────────────────────────────────────

--- a/app/routers/daily_chat.py
+++ b/app/routers/daily_chat.py
@@ -100,15 +100,12 @@ async def get_latest_session(
     session = result.scalar_one_or_none()
 
     if session is None:
-        session = ChatSession(date=date_str, title="新しいチャット")
-        db.add(session)
-        await db.commit()
-        await db.refresh(session)
-        messages: list[ChatMessage] = []
-    else:
-        messages = session.messages
+        # セッションがない場合は空パネルを表示（セッションは初回メッセージ時に作成）
+        return await _render_daily_chat_panel(request, date_str, None, [], db)
 
-    return await _render_daily_chat_panel(request, date_str, session, messages, db)
+    return await _render_daily_chat_panel(
+        request, date_str, session, session.messages, db
+    )
 
 
 # ── セッション作成 ─────────────────────────────────────────────────
@@ -136,6 +133,62 @@ async def create_session(
     await db.commit()
     await db.refresh(session)
     return await _render_daily_chat_panel(request, date_str, session, [], db)
+
+
+# ── 初回メッセージ（セッション作成 + メッセージ送信） ─────────────────
+@router.post("/{date_str}/first-message", response_class=HTMLResponse)
+async def first_message(
+    request: Request,
+    date_str: str,
+    message: str = Form(...),
+    db: AsyncSession = Depends(get_db),
+):
+    """セッションがない状態から初回メッセージを送信する。
+    セッション作成 → メッセージ送信 → パネル全体を返す。"""
+    session = ChatSession(date=date_str, title="新しいチャット")
+    db.add(session)
+    await db.flush()
+
+    # ユーザーメッセージを保存
+    user_msg = ChatMessage(session_id=session.id, role="user", content=message)
+    db.add(user_msg)
+    await db.flush()
+
+    # RAG コンテキストを構築
+    rag_context = await asyncio.get_event_loop().run_in_executor(
+        None, _build_daily_rag_context, date_str
+    )
+    session.rag_context = rag_context
+
+    # AI 応答を生成
+    gen_result = await _generate_daily_response(
+        date_str, [user_msg], message, rag_context
+    )
+
+    # AI メッセージを保存
+    ai_msg = ChatMessage(
+        session_id=session.id,
+        role="assistant",
+        content=gen_result["text"],
+        used_search=gen_result["used_search"],
+        search_sources=(
+            json.dumps(gen_result["sources"], ensure_ascii=False)
+            if gen_result["sources"]
+            else None
+        ),
+    )
+    db.add(ai_msg)
+
+    # タイトルを自動生成
+    session.title = await _generate_title(message)
+
+    await db.commit()
+    await db.refresh(session, attribute_names=["id"])
+
+    # パネル全体を返す（セッション情報 + メッセージ付き）
+    return await _render_daily_chat_panel(
+        request, date_str, session, [user_msg, ai_msg], db
+    )
 
 
 # ── セッション読み込み ─────────────────────────────────────────────
@@ -264,11 +317,8 @@ async def delete_session(
             request, date_str, remaining, remaining.messages, db
         )
 
-    new_session = ChatSession(date=date_str, title="新しいチャット")
-    db.add(new_session)
-    await db.commit()
-    await db.refresh(new_session)
-    return await _render_daily_chat_panel(request, date_str, new_session, [], db)
+    # セッションがなくなった場合は空パネルを表示（初回メッセージ時に作成）
+    return await _render_daily_chat_panel(request, date_str, None, [], db)
 
 
 # ── 内部ヘルパー ───────────────────────────────────────────────────
@@ -277,11 +327,25 @@ async def delete_session(
 async def _render_daily_chat_panel(
     request: Request,
     date_str: str,
-    session: ChatSession,
+    session: ChatSession | None,
     messages: list[ChatMessage],
     db: AsyncSession,
 ) -> HTMLResponse:
     """日毎チャットパネル HTML を生成する"""
+    if session is None:
+        return templates.TemplateResponse(
+            "components/chat/daily_panel.html",
+            {
+                "request": request,
+                "date_str": date_str,
+                "session": None,
+                "messages": [],
+                "all_sessions": [],
+                "current_index": 0,
+                "total_sessions": 0,
+            },
+        )
+
     stmt = (
         select(ChatSession)
         .where(ChatSession.date == date_str, ChatSession.article_id.is_(None))

--- a/app/routers/daily_chat.py
+++ b/app/routers/daily_chat.py
@@ -275,15 +275,21 @@ async def send_message(
     db.add(ai_msg)
 
     # 初回メッセージのときセッションタイトルを自動生成
+    new_title = None
     if len(session.messages) == 0:
-        session.title = await _generate_title(message)
+        new_title = await _generate_title(message)
+        session.title = new_title
 
     await db.commit()
 
-    return templates.TemplateResponse(
-        "components/chat/messages.html",
-        {"request": request, "messages": [ai_msg]},
-    )
+    ctx: dict = {
+        "request": request,
+        "messages": [ai_msg],
+    }
+    if new_title:
+        ctx["new_title"] = new_title
+        ctx["title_element_id"] = f"chat-title-{session_id}"
+    return templates.TemplateResponse("components/chat/messages.html", ctx)
 
 
 # ── セッション削除 ─────────────────────────────────────────────────

--- a/app/routers/daily_chat.py
+++ b/app/routers/daily_chat.py
@@ -373,12 +373,13 @@ async def _render_daily_chat_panel(
 
 def _extract_grounding_info(response) -> tuple[bool, list[dict], str]:
     """レスポンスからグラウンディング情報を抽出する"""
+    text = response.text or ""
     try:
         meta = response.candidates[0].grounding_metadata
         if not meta or not meta.grounding_chunks:
-            return False, [], response.text
+            return False, [], text
     except (AttributeError, IndexError):
-        return False, [], response.text
+        return False, [], text
 
     sources: list[dict] = []
     for chunk in meta.grounding_chunks:
@@ -387,9 +388,7 @@ def _extract_grounding_info(response) -> tuple[bool, list[dict], str]:
             sources.append({"title": web.title or "", "uri": web.uri or ""})
 
     if not sources:
-        return False, [], response.text
-
-    text = response.text
+        return False, [], text
     supports = meta.grounding_supports or []
     if supports:
         indexed = []

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -37,20 +37,29 @@
           if (needLoad) {
             this.loaded = true;
             var url = '/daily-chat/' + dateStr + '/sessions/latest';
-            // 広い画面用パネル
-            var desktop = document.getElementById('daily-chat-panel');
-            if (desktop) htmx.ajax('GET', url, {target: '#daily-chat-panel', swap: 'innerHTML'});
-            // 狭い画面用パネル
-            var mobile = document.getElementById('daily-chat-panel-mobile');
-            if (mobile) htmx.ajax('GET', url, {target: '#daily-chat-panel-mobile', swap: 'innerHTML'});
+            // 画面幅に応じて1つのパネルにのみ読み込む（二重リクエスト防止）
+            if (window.innerWidth >= 1024) {
+              var desktop = document.getElementById('daily-chat-panel');
+              if (desktop) htmx.ajax('GET', url, {target: '#daily-chat-panel', swap: 'innerHTML'});
+            } else {
+              var mobile = document.getElementById('daily-chat-panel-mobile');
+              if (mobile) htmx.ajax('GET', url, {target: '#daily-chat-panel-mobile', swap: 'innerHTML'});
+            }
           }
         }
       });
 
-      // dailyChat.open の変更を監視してスクロールロックを同期（Escape等で閉じた場合にも対応）
+      // dailyChat.open の変更を監視してスクロールロック・スティッキーバー位置を同期
       Alpine.effect(() => {
         var store = Alpine.store('dailyChat');
-        if (store) store._updateBodyScroll(store.open);
+        if (store) {
+          store._updateBodyScroll(store.open);
+          // スティッキーバーの right 位置を更新
+          var bar = document.getElementById('section-sticky-bar');
+          if (bar) {
+            bar.style.right = (store.open && window.innerWidth >= 1024) ? '420px' : '0';
+          }
+        }
       });
       // リサイズ時にもスクロールロック状態を再評価
       window.addEventListener('resize', () => {
@@ -248,8 +257,15 @@
     return clone;
   }
 
+  function updateStickyRight() {
+    if (!stickyWrap || !window.Alpine) return;
+    var chatOpen = Alpine.store('dailyChat') && Alpine.store('dailyChat').open;
+    stickyWrap.style.right = (chatOpen && window.innerWidth >= 1024) ? '420px' : '0';
+  }
+
   function updateBar() {
     if (!stickyWrap || !window.Alpine) return;
+    updateStickyRight();
 
     var sections = Array.from(document.querySelectorAll('section[data-section-title]'));
 

--- a/app/templates/components/chat/daily_panel.html
+++ b/app/templates/components/chat/daily_panel.html
@@ -31,7 +31,7 @@
       <button class="px-1.5 py-0.5 rounded border border-blue-400 bg-blue-500 text-blue-300 cursor-not-allowed shrink-0" disabled>‹</button>
       {% endif %}
 
-      <span class="text-white font-medium truncate min-w-0 flex-1">{{ session.title }}</span>
+      <span class="text-white font-medium truncate min-w-0 flex-1" id="chat-title-{{ session.id }}">{{ session.title }}</span>
 
       {% if current_index < total_sessions - 1 %}
       <button class="px-1.5 py-0.5 rounded border border-blue-400 bg-blue-500 hover:bg-blue-400 text-white shrink-0"

--- a/app/templates/components/chat/daily_panel.html
+++ b/app/templates/components/chat/daily_panel.html
@@ -2,7 +2,7 @@
   日毎チャットパネル (daily_panel.html)
   必要変数:
     date_str       : str (YYYY-MM-DD)
-    session        : ChatSession
+    session        : ChatSession | None
     messages       : list[ChatMessage]
     all_sessions   : list[ChatSession]
     current_index  : int
@@ -19,6 +19,7 @@
               title="チャットを閉じる">✕</button>
       <span class="text-blue-100 shrink-0 text-xs">{{ date_str }}</span>
 
+      {% if session %}
       {% if current_index > 0 %}
       <button class="px-1.5 py-0.5 rounded border border-blue-400 bg-blue-500 hover:bg-blue-400 text-white shrink-0"
               hx-get="/daily-chat/{{ date_str }}/sessions/{{ all_sessions[current_index - 1].id }}"
@@ -44,8 +45,12 @@
       {% endif %}
 
       <span class="text-xs text-blue-200 shrink-0">{{ current_index + 1 }}/{{ total_sessions }}</span>
+      {% else %}
+      <span class="text-white font-medium truncate min-w-0 flex-1">新しいチャット</span>
+      {% endif %}
     </div>
     <!-- 下段: アクションボタン -->
+    {% if session %}
     <div class="flex items-center gap-1.5">
       <button class="flex items-center gap-1 text-xs bg-white text-blue-700 px-2.5 py-1 rounded-lg hover:bg-blue-50 transition font-medium"
               hx-post="/daily-chat/{{ date_str }}/sessions"
@@ -61,9 +66,11 @@
         削除
       </button>
     </div>
+    {% endif %}
   </div>
 
   <!-- メッセージ一覧 -->
+  {% if session %}
   <div class="chat-messages px-4 py-3 space-y-3 overflow-y-auto flex-1"
        id="daily-messages-{{ session.id }}">
     {% for msg in messages %}
@@ -75,8 +82,17 @@
     </p>
     {% endif %}
   </div>
+  {% else %}
+  <div class="chat-messages px-4 py-3 space-y-3 overflow-y-auto flex-1"
+       id="daily-messages-new">
+    <p class="text-center text-gray-400 text-sm py-4">
+      {{ date_str }} の記事全体について質問してください
+    </p>
+  </div>
+  {% endif %}
 
   <!-- 入力フォーム -->
+  {% if session %}
   <form class="px-4 py-3 border-t border-blue-200 bg-blue-100/50 flex gap-2 items-end shrink-0"
         id="daily-chat-form-{{ session.id }}"
         hx-post="/daily-chat/{{ date_str }}/sessions/{{ session.id }}/messages"
@@ -99,5 +115,30 @@
       送信
     </button>
   </form>
+  {% else %}
+  <!-- 初回メッセージ用フォーム: セッション作成 + メッセージ送信を同時に行う -->
+  <form class="px-4 py-3 border-t border-blue-200 bg-blue-100/50 flex gap-2 items-end shrink-0"
+        id="daily-chat-form-new"
+        hx-post="/daily-chat/{{ date_str }}/first-message"
+        hx-target="closest .daily-chat-target"
+        hx-swap="innerHTML"
+        data-chat-form
+        data-messages-id="daily-messages-new"
+        data-thinking-id="daily-thinking-new"
+        data-thinking-label-id="daily-thinking-label-new"
+        data-submit-btn-id="daily-chat-submit-new">
+    <textarea name="message" required rows="1"
+              placeholder="今日の記事について質問… (Ctrl+Enter で送信)"
+              class="flex-1 border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 resize-none overflow-hidden"
+              autocomplete="off"
+              onkeydown="if(event.key==='Enter'&&(event.ctrlKey||event.metaKey)){event.preventDefault();this.closest('form').requestSubmit();}"
+              oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,160)+'px'"></textarea>
+    <button type="submit"
+            id="daily-chat-submit-new"
+            class="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-700 transition shrink-0">
+      送信
+    </button>
+  </form>
+  {% endif %}
 
 </div>

--- a/app/templates/components/chat/messages.html
+++ b/app/templates/components/chat/messages.html
@@ -1,7 +1,11 @@
 <!--
   HTMX で append されるメッセージ断片 (chat_messages.html)
   必要変数: messages (list[ChatMessage])
+  オプション: new_title (str), title_element_id (str) — タイトル自動生成時にOOB swapで即時反映
 -->
 {% for msg in messages %}
 {% include "components/chat/message_item.html" %}
 {% endfor %}
+{% if new_title and title_element_id %}
+<span id="{{ title_element_id }}" hx-swap-oob="innerHTML">{{ new_title }}</span>
+{% endif %}

--- a/app/templates/components/chat/panel.html
+++ b/app/templates/components/chat/panel.html
@@ -28,7 +28,7 @@
       <button class="px-1.5 py-0.5 rounded border bg-white text-gray-300 cursor-not-allowed shrink-0" disabled>‹</button>
       {% endif %}
 
-      <span class="text-gray-700 font-medium truncate min-w-0 flex-1">{{ session.title }}</span>
+      <span class="text-gray-700 font-medium truncate min-w-0 flex-1" id="chat-title-{{ session.id }}">{{ session.title }}</span>
 
       {% if current_index < total_sessions - 1 %}
       <button class="px-1.5 py-0.5 rounded border bg-white hover:bg-gray-100 text-gray-600 shrink-0"


### PR DESCRIPTION
## Summary
- **#32**: GitHub Trending でチャットが機能しない問題を修正（`_get_or_create_article` に `github_trending`・`industry_news` カテゴリ追加）
- **#33**: 日毎チャットの空セッション自動作成を廃止し、初回メッセージ送信時に遅延作成する方式に変更
- **#33**: スティッキーバーがチャットパネルの裏に隠れる表示崩れを修正

## 変更内容
- `app/routers/chat.py`: `_get_or_create_article` のカテゴリリストに `github_trending`・`industry_news` を追加
- `app/routers/daily_chat.py`: セッション遅延作成、`POST /{date}/first-message` エンドポイント追加、削除後の空セッション自動作成廃止
- `app/templates/base.html`: `toggle()` の二重リクエスト防止、スティッキーバーの `right` 位置をチャットパネル開閉に連動
- `app/templates/components/chat/daily_panel.html`: `session=None` 時の初回メッセージ用フォーム対応

## Test plan
- [ ] GitHub Trending の記事カードでチャットが正常に動作すること
- [ ] 日毎チャットパネルを開いただけでは DB にセッションが作成されないこと
- [ ] 初回メッセージ送信でセッション作成 + タイトル自動生成が動作すること
- [ ] セクション見出しのスティッキーバーがチャットパネルの裏に隠れないこと
- [ ] モバイル表示でもチャットパネルが正常に動作すること

Closes #32
Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)