### PR TITLE
#36 LLM・AIエージェント動向カテゴリ(ai_dev)を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@
 | Zenn | AI・機械学習・LLM 関連記事 | RSS フィード |
 | Reddit | r/MachineLearning / r/artificial / r/LocalLLaMA | JSON API |
 | GitHub Trending | 全言語の AI/LLM 関連トレンドリポジトリ（4軸ランキング、各10件） | Web スクレイピング + GitHub REST API |
+| LLM・AIエージェント動向 | Claude Code / Codex / Cursor / Copilot 等の公式アップデート + Mistral / HuggingFace / DeepMind のモデルリリース + LLM/エージェント/コーディングAI の性能・ベンチマーク記事 | 公式 RSS/Atom + キーワードフィルタ news |
 
 > GitHub Trending の詳細は [docs/github_trending.md](docs/github_trending.md) を参照してください。
+> 「LLM・AIエージェント動向」(`ai_dev` カテゴリ) の収集元は `app/config.py` の `ai_dev_rss_feeds` / `ai_dev_news_feeds` で定義しています。
 
 ### 検索テーマ（Theme Search）
 

--- a/app/README.md
+++ b/app/README.md
@@ -37,7 +37,8 @@ app/
 │       ├── industry_news.py # 海外ニュースメディア RSS + キーワードフィルタ
 │       ├── community.py     # Qiita API / Zenn RSS / Reddit JSON API
 │       ├── python_news.py   # (旧) Python 限定 GitHub Trending（後方互換用）
-│       └── github_trending.py # GitHub Trending 全言語 AI/LLM フィルタ付き収集
+│       ├── github_trending.py # GitHub Trending 全言語 AI/LLM フィルタ付き収集
+│       └── ai_dev.py        # LLM・AIエージェント動向（公式アップデート + 性能ニュース）
 └── templates/
     ├── base.html        # 共通レイアウト (Tailwind CDN, HTMX, Alpine.js)
     ├── pages/           # フルページテンプレート

--- a/app/config.py
+++ b/app/config.py
@@ -130,6 +130,76 @@ class Settings:
         "Perplexity",
     ]
 
+    # ── LLM・AIエージェント動向（ai_dev カテゴリ） ──────────────
+    # コーディングAI ツール・LLM ベンダーの公式アップデート（changelog/release/blog）RSS。
+    # 既存 industry とは別に、Claude Code / Codex / Cursor / Copilot などの開発ツールや
+    # Mistral / HuggingFace / DeepMind のモデルリリースを横断収集する。
+    # （URL は 2026-06 時点で feed XML を返すことを確認済み）
+    ai_dev_rss_feeds: dict[str, str] = {
+        "Claude Code": "https://github.com/anthropics/claude-code/releases.atom",
+        "OpenAI Codex": "https://github.com/openai/codex/releases.atom",
+        "Cursor": "https://www.cursor.com/changelog/rss.xml",
+        "GitHub Copilot": "https://github.blog/changelog/label/copilot/feed/",
+        "Mistral": "https://mistral.ai/rss.xml",
+        "Hugging Face": "https://huggingface.co/blog/feed.xml",
+        "Google DeepMind": "https://deepmind.google/blog/rss.xml",
+    }
+    ai_dev_max_per_source: int = 5  # 公式フィード1ソースあたりの上限
+
+    # LLM/エージェント/コーディングAI の性能・ベンチマーク記事を扱う実務寄りニュース源。
+    # ai_dev_filter_keywords でフィルタする。
+    ai_dev_news_feeds: list[str] = [
+        "https://simonwillison.net/atom/everything/",
+        "https://venturebeat.com/category/ai/feed/",
+        "https://jack-clark.net/feed/",
+    ]
+    ai_dev_news_max_results: int = 15
+    # LLM/AIエージェント/コーディングAI 関連かを判定するキーワード
+    ai_dev_filter_keywords: list[str] = [
+        "LLM",
+        "large language model",
+        "frontier model",
+        "foundation model",
+        "GPT",
+        "ChatGPT",
+        "Claude",
+        "Claude Code",
+        "Anthropic",
+        "OpenAI",
+        "Codex",
+        "Gemini",
+        "Gemma",
+        "DeepMind",
+        "Llama",
+        "Mistral",
+        "Qwen",
+        "DeepSeek",
+        "Grok",
+        "coding agent",
+        "AI agent",
+        "agentic",
+        "agent",
+        "LangChain",
+        "Cursor",
+        "Copilot",
+        "Windsurf",
+        "Aider",
+        "Devin",
+        "code generation",
+        "MCP",
+        "Model Context Protocol",
+        "tool use",
+        "benchmark",
+        "SWE-bench",
+        "HumanEval",
+        "LiveCodeBench",
+        "leaderboard",
+        "reasoning model",
+        "context window",
+        "open weights",
+        "model release",
+    ]
+
     # OpenReview 対象学会
     # NeurIPS / ICLR / ICML は OpenReview 上に投稿を公開している（取得可能）。
     # CVPR / ICCV / ECCV は CV の主要学会だが現状は投稿を非公開（将来公開時に備えて残す）。

--- a/app/main.py
+++ b/app/main.py
@@ -162,7 +162,13 @@ async def reprocess_summaries(date_str: str | None = None):
             target_date_str = raw.get("date", date_str)
 
         paper_cats = ["cv", "lg", "ai", "cl"]
-        article_cats = ["industry", "industry_news", "community", "github_trending"]
+        article_cats = [
+            "industry",
+            "industry_news",
+            "community",
+            "github_trending",
+            "ai_dev",
+        ]
         tasks = [summarize_items(data[c], "paper") for c in paper_cats] + [
             summarize_items(data[c], "article") for c in article_cats
         ]

--- a/app/routers/archive.py
+++ b/app/routers/archive.py
@@ -52,6 +52,7 @@ async def archive_day(
         "industry_news",
         "community",
         "github_trending",
+        "ai_dev",
     ]:
         all_items.extend(data.get(key, []))
 
@@ -118,6 +119,7 @@ async def archive_day(
             "github_trending_by_weekly": gt_by_weekly,
             "github_trending_by_monthly": gt_by_monthly,
             "github_trending_by_total": gt_by_total,
+            "ai_dev_items": data.get("ai_dev", []),
             "available_dates": available_dates,
             "user_tags_by_id": user_tags_by_id,
         },

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -333,6 +333,7 @@ async def _get_or_create_article(article_id: str, db: AsyncSession) -> Article |
         "industry_news",
         "community",
         "github_trending",
+        "ai_dev",
         "python",
     ]
     for date_str in list_available_dates():

--- a/app/routers/daily_chat.py
+++ b/app/routers/daily_chat.py
@@ -60,6 +60,7 @@ def _build_daily_rag_context(date_str: str) -> str:
         "industry_news": "企業動向（その他報道）",
         "community": "コミュニティ",
         "github_trending": "GitHub Trending",
+        "ai_dev": "LLM・AIエージェント動向",
     }
 
     for cat, items in data.items():

--- a/app/routers/tags.py
+++ b/app/routers/tags.py
@@ -34,6 +34,11 @@ CATEGORY_META = {
         "title": "GitHub Trending",
         "is_paper": False,
     },
+    "ai_dev": {
+        "icon": "🛠️",
+        "title": "LLM・AIエージェント動向",
+        "is_paper": False,
+    },
 }
 
 CATEGORY_ORDER = [
@@ -45,6 +50,7 @@ CATEGORY_ORDER = [
     "industry_news",
     "community",
     "github_trending",
+    "ai_dev",
 ]
 
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -58,6 +58,7 @@ class DailyCollection(BaseModel):
         "community",
         "python",
         "github_trending",
+        "ai_dev",
     ]
     collected_at: str  # ISO 8601 収集実行日時 (JST)
     total: int = 0

--- a/app/services/collector/ai_dev.py
+++ b/app/services/collector/ai_dev.py
@@ -1,0 +1,232 @@
+"""
+LLM・AIエージェント動向収集モジュール（ai_dev カテゴリ）
+
+2つのパスで「全ソース横断」収集する:
+  Pass A: コーディングAI ツール・LLM ベンダーの公式アップデート（changelog/release/blog）RSS
+          → settings.ai_dev_rss_feeds（Claude Code / Codex / Cursor / Copilot / Mistral / HF / DeepMind）
+  Pass B: LLM/エージェント/コーディングAI の性能・ベンチマーク記事
+          → settings.ai_dev_news_feeds をキーワード（ai_dev_filter_keywords）でフィルタ
+
+industry.py / industry_news.py のパターンを踏襲。要約は "industry" リテラルで行う想定。
+"""
+
+import asyncio
+import hashlib
+import logging
+import time
+from datetime import date, timedelta
+from email.utils import parsedate_to_datetime
+from html.parser import HTMLParser
+
+import feedparser
+import httpx
+
+from app.config import settings
+from app.schemas import ArticleItem
+
+logger = logging.getLogger(__name__)
+
+
+async def collect_ai_dev(target_date: date | None = None) -> list[ArticleItem]:
+    """公式アップデート + キーワード該当ニュースを収集し、id で重複除去して返す。"""
+    if target_date is None:
+        target_date = date.today() - timedelta(days=1)
+
+    official = await _collect_official(target_date)
+    news = await _collect_news(target_date)
+
+    # id で重複除去（公式を優先）
+    merged: dict[str, ArticleItem] = {}
+    for item in official + news:
+        merged.setdefault(item.id, item)
+
+    items = list(merged.values())
+    logger.info(
+        f"LLM・AIエージェント動向 収集完了: {len(items)} 件 "
+        f"(公式 {len(official)} / ニュース {len(news)})"
+    )
+    return items
+
+
+# ── Pass A: 公式アップデート ───────────────────────────────────
+
+
+async def _collect_official(target_date: date) -> list[ArticleItem]:
+    tasks = [
+        _fetch_official(name, url, target_date)
+        for name, url in settings.ai_dev_rss_feeds.items()
+    ]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    items: list[ArticleItem] = []
+    for name, result in zip(settings.ai_dev_rss_feeds.keys(), results):
+        if isinstance(result, list):
+            items.extend(result)
+        else:
+            logger.warning(f"ai_dev 公式フィード収集失敗 ({name}): {result}")
+    return items
+
+
+async def _fetch_official(name: str, url: str, target_date: date) -> list[ArticleItem]:
+    feed = await _fetch_feed(url)
+    if feed is None:
+        return []
+
+    slug = name.lower().replace(" ", "-")
+    items: list[ArticleItem] = []
+    for entry in feed.entries:
+        entry_date = _parse_entry_date(entry)
+        if entry_date != target_date:
+            continue
+
+        title = entry.get("title", "")
+        # プレリリース（alpha/beta/rc/dev/nightly）は安定版に絞るためスキップ
+        if _is_prerelease(title):
+            continue
+        link = entry.get("link", "")
+        summary = _strip_html(entry.get("summary", "") or entry.get("description", ""))
+
+        items.append(
+            ArticleItem(
+                id=f"ai_dev:{slug}:{_url_to_id(link)}",
+                title_en=title,
+                abstract_en=summary[:800],
+                published_date=target_date.isoformat(),
+                url=link,
+                source_type="rss",
+                source_name=name,
+                tags=["ai_dev", slug, "official"],
+            )
+        )
+        if len(items) >= settings.ai_dev_max_per_source:
+            break
+
+    logger.info(f"ai_dev 公式 ({name}): {len(items)} 件")
+    return items
+
+
+# ── Pass B: キーワード該当ニュース ─────────────────────────────
+
+
+async def _collect_news(target_date: date) -> list[ArticleItem]:
+    tasks = [_fetch_news(url, target_date) for url in settings.ai_dev_news_feeds]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    items: list[ArticleItem] = []
+    for url, result in zip(settings.ai_dev_news_feeds, results):
+        if isinstance(result, list):
+            items.extend(result)
+        else:
+            logger.warning(f"ai_dev ニュース収集失敗 ({url}): {result}")
+
+    # キーワードフィルタ（タイトル or 本文に LLM/エージェント/コーディングAI 関連語）
+    keywords_lower = [kw.lower() for kw in settings.ai_dev_filter_keywords]
+    filtered = [
+        item
+        for item in items
+        if any(
+            kw in (item.title_en + " " + item.abstract_en).lower()
+            for kw in keywords_lower
+        )
+    ]
+    filtered = filtered[: settings.ai_dev_news_max_results]
+    logger.info(f"ai_dev ニュース: {len(filtered)} 件 (フィルタ前 {len(items)} 件)")
+    return filtered
+
+
+async def _fetch_news(url: str, target_date: date) -> list[ArticleItem]:
+    feed = await _fetch_feed(url)
+    if feed is None:
+        return []
+
+    source_name = feed.feed.get("title", url)
+    items: list[ArticleItem] = []
+    for entry in feed.entries:
+        entry_date = _parse_entry_date(entry)
+        # 日付が取れない場合は含める（緩めに）、取れたら前日のみ
+        if entry_date is not None and entry_date != target_date:
+            continue
+
+        title = entry.get("title", "")
+        link = entry.get("link", "")
+        summary = _strip_html(entry.get("summary", "") or entry.get("description", ""))
+
+        items.append(
+            ArticleItem(
+                id=f"ai_dev_news:{_url_to_id(link)}",
+                title_en=title,
+                abstract_en=summary[:800],
+                published_date=target_date.isoformat() if entry_date else "",
+                url=link,
+                source_type="rss",
+                source_name=source_name,
+                tags=["ai_dev", "news"],
+            )
+        )
+
+    logger.info(f"ai_dev ニュース ({source_name}): {len(items)} 件")
+    return items
+
+
+# ── ユーティリティ ────────────────────────────────────────────
+
+
+async def _fetch_feed(url: str):
+    """RSS/Atom を取得して feedparser でパースする。失敗時 None。"""
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.get(
+                url,
+                follow_redirects=True,
+                headers={"User-Agent": "Mozilla/5.0 (compatible; AI-Daily-Survey/1.0)"},
+            )
+            resp.raise_for_status()
+            return feedparser.parse(resp.text)
+    except Exception as e:
+        logger.warning(f"ai_dev フィード取得失敗 ({url}): {e}")
+        return None
+
+
+def _parse_entry_date(entry) -> date | None:
+    for field in ("published", "updated", "created"):
+        raw = entry.get(f"{field}_parsed") or entry.get(field)
+        if raw is None:
+            continue
+        try:
+            if hasattr(raw, "tm_year"):
+                return date(*time.gmtime(time.mktime(raw))[:3])
+            dt = parsedate_to_datetime(str(raw))
+            return dt.date()
+        except Exception:
+            continue
+    return None
+
+
+def _strip_html(text: str) -> str:
+    class Stripper(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self.result = []
+
+        def handle_data(self, d):
+            self.result.append(d)
+
+        def get_data(self):
+            return " ".join(self.result)
+
+    s = Stripper()
+    s.feed(text)
+    return s.get_data()
+
+
+_PRERELEASE_MARKERS = ("alpha", "beta", "-rc", "rc.", ".dev", "nightly", "canary")
+
+
+def _is_prerelease(title: str) -> bool:
+    """バージョンタイトルがプレリリース（alpha/beta/rc 等）か判定する。"""
+    t = title.lower()
+    return any(m in t for m in _PRERELEASE_MARKERS)
+
+
+def _url_to_id(url: str) -> str:
+    return hashlib.md5(url.encode()).hexdigest()[:12]

--- a/app/services/digest.py
+++ b/app/services/digest.py
@@ -53,6 +53,7 @@ async def generate_digest(
     industry_news: list[ArticleItem],
     community_items: list[ArticleItem],
     github_trending_items: list[ArticleItem],
+    ai_dev_items: list[ArticleItem] | None = None,
     *,
     target_date_str: str | None = None,
 ) -> str:
@@ -71,6 +72,7 @@ async def generate_digest(
         industry_news,
         community_items,
         github_trending_items,
+        ai_dev_items or [],
     )
 
     coverage_date = target_date_str or date_str
@@ -110,6 +112,7 @@ def _build_context(
     industry_news: list[ArticleItem],
     community_items: list[ArticleItem],
     github_trending_items: list[ArticleItem],
+    ai_dev_items: list[ArticleItem] | None = None,
 ) -> str:
     sections = []
 
@@ -133,6 +136,7 @@ def _build_context(
     add_section("AI 企業動向", industry_news, is_paper=False)
     add_section("SNS・コミュニティ", community_items, is_paper=False)
     add_section("GitHub Trending", github_trending_items, is_paper=False)
+    add_section("LLM・AIエージェント動向", ai_dev_items or [], is_paper=False)
 
     return "\n\n".join(sections)
 

--- a/app/services/pipeline.py
+++ b/app/services/pipeline.py
@@ -21,6 +21,7 @@ from app.services.collector.industry import collect_industry
 from app.services.collector.industry_news import collect_industry_news
 from app.services.collector.community import collect_community
 from app.services.collector.github_trending import collect_github_trending
+from app.services.collector.ai_dev import collect_ai_dev
 from app.services.summarizer import summarize_items
 from app.services.digest import generate_digest, load_digest
 from app.services.notifier import CollectionReport, send_completion_email
@@ -100,6 +101,14 @@ async def run_daily_pipeline(collection_date: date | None = None) -> None:
     except Exception as e:
         errors.append(f"GitHub Trending: {e}")
         logger.error(f"GitHub Trending 収集失敗: {e}")
+    await asyncio.sleep(_INTER_SOURCE_DELAY)
+
+    ai_dev_items: list[ArticleItem] = []
+    try:
+        ai_dev_items = await collect_ai_dev(target_date)
+    except Exception as e:
+        errors.append(f"LLM・AIエージェント動向: {e}")
+        logger.error(f"LLM・AIエージェント動向 収集失敗: {e}")
 
     lg_papers = arxiv_results.get("cs.LG", [])
     ai_papers = arxiv_results.get("cs.AI", [])
@@ -138,6 +147,7 @@ async def run_daily_pipeline(collection_date: date | None = None) -> None:
         industry_news_items,
         community_items,
         github_trending_items,
+        ai_dev_items,
     ) = await asyncio.gather(
         summarize_items(cv_arxiv_papers, "paper"),
         summarize_items(openreview_items, "paper"),
@@ -148,6 +158,7 @@ async def run_daily_pipeline(collection_date: date | None = None) -> None:
         summarize_items(industry_news_items, "industry"),
         summarize_items(community_items, "article"),
         summarize_items(github_trending_items, "article"),
+        summarize_items(ai_dev_items, "industry"),
     )
 
     # ── 3. JSON 保存 ────────────────────────────────────────────
@@ -167,6 +178,7 @@ async def run_daily_pipeline(collection_date: date | None = None) -> None:
     _save_collection(
         collection_date_str, target_date_str, "github_trending", github_trending_items
     )
+    _save_collection(collection_date_str, target_date_str, "ai_dev", ai_dev_items)
 
     # 収集件数を記録
     report.counts = {
@@ -179,6 +191,7 @@ async def run_daily_pipeline(collection_date: date | None = None) -> None:
         "企業動向（その他報道）": len(industry_news_items),
         "コミュニティ": len(community_items),
         "GitHub Trending": len(github_trending_items),
+        "LLM・AIエージェント動向": len(ai_dev_items),
     }
 
     # 要約失敗件数を集計してレポートに反映（無音の劣化を可視化）
@@ -192,6 +205,7 @@ async def run_daily_pipeline(collection_date: date | None = None) -> None:
         industry_news_items,
         community_items,
         github_trending_items,
+        ai_dev_items,
     ]
     summarize_failures = sum(
         1 for batch in _all_batches for it in batch if not it.summarized
@@ -239,6 +253,7 @@ async def run_daily_pipeline(collection_date: date | None = None) -> None:
         industry_news_items,
         community_items,
         github_trending_items,
+        ai_dev_items,
     )
 
     # ── 3.5. テーマ検索 ────────────────────────────────────────
@@ -257,6 +272,7 @@ async def run_daily_pipeline(collection_date: date | None = None) -> None:
             "industry_news": industry_news_items,
             "community": community_items,
             "github_trending": github_trending_items,
+            "ai_dev": ai_dev_items,
         },
         report,
         errors,
@@ -274,6 +290,7 @@ async def run_daily_pipeline(collection_date: date | None = None) -> None:
             industry_items,
             community_items,
             github_trending_items,
+            ai_dev_items,
             target_date_str=target_date_str,
         )
         digest_content = load_digest(collection_date_str) or ""
@@ -308,6 +325,7 @@ def _save_collection(
         "community",
         "python",
         "github_trending",
+        "ai_dev",
     ],
     items: list[ArticleItem],
 ) -> None:
@@ -350,6 +368,7 @@ async def _register_articles_to_db(
         "industry_news",
         "community",
         "github_trending",
+        "ai_dev",
     ]
 
     async with AsyncSessionLocal() as session:
@@ -419,6 +438,7 @@ def load_daily_data(date_str: str) -> dict[str, list[ArticleItem]]:
         "industry_news",
         "community",
         "github_trending",
+        "ai_dev",
     ]
     result: dict[str, list[ArticleItem]] = {}
 

--- a/app/templates/components/article/section.html
+++ b/app/templates/components/article/section.html
@@ -32,6 +32,7 @@
       {% elif section_id == 'industry' %}bg-gradient-to-r from-slate-700 to-slate-600
       {% elif section_id == 'community' %}bg-gradient-to-r from-teal-700 to-cyan-600
       {% elif section_id == 'github-trending' %}bg-gradient-to-r from-emerald-700 to-green-500
+      {% elif section_id == 'ai_dev' %}bg-gradient-to-r from-violet-700 to-fuchsia-600
       {% else %}bg-gradient-to-r from-blue-800 to-indigo-600{% endif %}
       text-white px-4 sm:px-6 py-4 sm:py-5">
       <!-- 装飾 -->

--- a/app/templates/pages/index.html
+++ b/app/templates/pages/index.html
@@ -19,7 +19,7 @@
       <option value="{{ d }}" {% if d == date_str %}selected{% endif %}>{{ d }}</option>
       {% endfor %}
     </select>
-    {% set has_existing_data = digest_html or cv_papers or lg_papers or ai_papers or cl_papers or industry_items or community_items or python_items %}
+    {% set has_existing_data = digest_html or cv_papers or lg_papers or ai_papers or cl_papers or industry_items or community_items or python_items or ai_dev_items %}
     <button
       hx-post="/admin/run-pipeline"
       hx-vals='{"date_str": "{{ date_str }}"}'
@@ -226,7 +226,18 @@
 {% include "components/article/github_trending_section.html" %}
 {% endif %}
 
-{% if not (cv_papers or openreview_papers or lg_papers or ai_papers or cl_papers or industry_items or industry_news_items or community_items or github_trending_items) %}
+<!-- ⑦ LLM・AIエージェント動向 -->
+{% if ai_dev_items %}
+{% set section_id = "ai_dev" %}
+{% set section_icon = "🛠️" %}
+{% set section_title = "LLM・AIエージェント動向（公式アップデート・性能ニュース）" %}
+{% set items = ai_dev_items %}
+{% set is_paper = false %}
+{% set subsection = false %}
+{% include "components/article/section.html" %}
+{% endif %}
+
+{% if not (cv_papers or openreview_papers or lg_papers or ai_papers or cl_papers or industry_items or industry_news_items or community_items or github_trending_items or ai_dev_items) %}
 <div class="text-center py-20 text-gray-400">
   <p class="text-5xl mb-4">📭</p>
   <p class="text-lg font-medium text-slate-500">{{ date_str }} のデータがまだありません</p>

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -164,7 +164,8 @@ JST 12:00 (APScheduler)
     ├── collect_industry(target_date)        → 企業公式 RSS（自社発表）
     ├── collect_industry_news(target_date)   → 海外ニュース RSS（その他報道）
     ├── collect_community(target_date)       → Qiita / Zenn / Reddit
-    └── collect_github_trending(target_date)  → GitHub Trending（全言語, AI/LLMキーワードフィルタ, 3期間スクレイピング）
+    ├── collect_github_trending(target_date)  → GitHub Trending（全言語, AI/LLMキーワードフィルタ, 3期間スクレイピング）
+    └── collect_ai_dev(target_date)          → LLM・AIエージェント動向（公式アップデート + 性能ニュース）
     │
     ▼
 ② 重複除去（論文系のみ: cv / openreview / lg / ai / cl）
@@ -246,6 +247,15 @@ JST 12:00 (APScheduler)
     - description 変更あり or 30日超経過 → 新たに要約を生成
   - キーワードは `data/github_trending_keywords.json` でカスタマイズ可能（UI からも変更可能）
   - 詳細は [docs/github_trending.md](github_trending.md) を参照
+
+### 5.7 LLM・AIエージェント動向（`ai_dev`）
+
+- **公式アップデート（Pass A）**: `settings.ai_dev_rss_feeds` の RSS/Atom を並列取得
+  - Claude Code / OpenAI Codex（GitHub releases Atom）、Cursor / GitHub Copilot（changelog RSS）、Mistral / Hugging Face / Google DeepMind（blog RSS）
+  - 前日分のみ採用。バージョンタイトルが alpha/beta/rc/dev/nightly のプレリリースは除外。1ソース最大 `ai_dev_max_per_source` 件
+- **性能・ベンチマークニュース（Pass B）**: `settings.ai_dev_news_feeds`（Simon Willison / VentureBeat AI / Import AI）を取得し、`ai_dev_filter_keywords`（LLM/agent/coding-AI 関連語）でフィルタ。最大 `ai_dev_news_max_results` 件
+- 2パスを `id` で重複除去してマージ。要約は `"industry"` リテラル（定量指標を抽出）
+- 収集元は `app/config.py` で定義（環境変数ではない）。トップ/アーカイブの「LLM・AIエージェント動向」セクション（violet）に表示
 
 ---
 


### PR DESCRIPTION
Closes #36

## 概要
LLM / AIエージェント / コーディングAI（Claude Code・Codex・Gemini・Qwen・DeepSeek 等）の最新動向を日々キャッチアップする新カテゴリ `ai_dev`（表示「LLM・AIエージェント動向」）を、AI企業動向/コミュニティと並列のセクションとして追加します。

## 収集内容（新 collector `app/services/collector/ai_dev.py`）
- **公式アップデート (Pass A)**: Claude Code / OpenAI Codex（GitHub releases Atom）、Cursor / GitHub Copilot（changelog RSS）、Mistral / Hugging Face / Google DeepMind（blog RSS）。前日分のみ採用、プレリリース（alpha/beta/rc/dev/nightly）は除外。
- **性能・ベンチマークニュース (Pass B)**: Simon Willison / VentureBeat AI / Import AI を `ai_dev_filter_keywords`（LLM/agent/coding-AI 関連語）でフィルタ。
- 2パスを id で重複除去してマージ。要約は `"industry"` リテラル（定量指標を抽出）。

> 収集元はすべて 2026-06 時点で feed XML を返すことを検証済み。Qwen/DeepSeek/xAI/Anthropic は公式 RSS が無い/404 のため、Hugging Face + キーワードニュースで間接カバー。

## 配線
schemas / pipeline（収集・要約・保存・件数・要約失敗集計・DB登録・テーマ検索ソース・load_daily_data）/ archive / index.html セクション⑦(violet) / section.html / tags(META・ORDER) / digest / chat / daily_chat / reprocess。`source_type="rss"` を使うため source_type Literal と card.html は変更不要。

## 検証
- 全7公式フィード疎通、`collect_ai_dev` → Gemini 要約 → 保存 → /archive 表示・/tags 表示をライブ確認
- ruff / mypy / format 全通過、配線の完全性・DB登録の位置整合を確認

## 補足（別途要対応の発見）
既存 industry フィードのうち Anthropic (`anthropic.com/rss.xml`) と Meta (`ai.meta.com/blog/rss/`) が現在 404 を返しサイレント失敗しています。本PRのスコープ外のため未修正ですが、別途差し替えを推奨します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)