### PR TITLE
企業動向フィードの404を修正（Anthropic / Meta）

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -90,11 +90,16 @@ class Settings:
     ]
 
     # 企業ブログ RSS
+    # 注: Anthropic は公式 RSS を廃止（anthropic.com/rss.xml 等が 404）したため、
+    #     anthropic.com を対象にした Google News RSS で自社発表を拾う。
+    #     Meta も AI ブログ (ai.meta.com/blog/rss) が 404 化したため、公式の
+    #     Meta Engineering ブログ RSS に差し替え（AI/システム系を扱い、企業ニュースの
+    #     ノイズが少ない）。
     industry_rss_feeds: dict[str, str] = {
         "OpenAI": "https://openai.com/blog/rss.xml",
         "Google": "https://blog.google/technology/ai/rss/",
-        "Anthropic": "https://www.anthropic.com/rss.xml",
-        "Meta": "https://ai.meta.com/blog/rss/",
+        "Anthropic": "https://news.google.com/rss/search?q=site:anthropic.com&hl=en-US&gl=US&ceid=US:en",
+        "Meta": "https://engineering.fb.com/feed/",
         "Amazon": "https://aws.amazon.com/blogs/machine-learning/feed/",
         "Alibaba": "https://www.alibabacloud.com/blog/feed/tag/ai",
     }


### PR DESCRIPTION
## 概要
既存の「AI企業動向（自社発表）」industry フィードのうち、現在 404 を返してサイレント失敗していた Anthropic と Meta を、検証済みの働くフィードに差し替えます。

## 変更
| 企業 | 旧（404） | 新 |
|------|-----------|----|
| Anthropic | `anthropic.com/rss.xml` | `site:anthropic.com` の Google News RSS |
| Meta | `ai.meta.com/blog/rss/` | `engineering.fb.com/feed/`（Meta Engineering 公式ブログ） |

- **Anthropic**: 公式 RSS は全パス（`/rss.xml`, `/news/rss.xml`, `/feed` 等）が 404 で、Anthropic は公式 RSS を廃止済み。コミュニティミラーは 2024 年で陳腐化。`site:anthropic.com` の Google News RSS のみが最新（2026-06-09）で Anthropic 自社ページを拾えるため採用。
- **Meta**: AI ブログ RSS（`ai.meta.com/blog/rss`）が 404 化。公式の Meta Engineering ブログ（`engineering.fb.com/feed/`）は AI/システム系を扱い、`about.fb.com/news`（企業ニュースのノイズ大）より AI サーベイ向き。

## 検証
- `collect_industry(2026-06-03)` → Anthropic 5 / Meta 1（投稿日）、`collect_industry(2026-06-08)` → Anthropic 2 / Meta 0 を確認。404 エラーは解消。
- Anthropic 項目は実際の発表（例: "Paving the way for agents in biology - Anthropic"）で、URL は anthropic.com に解決する Google News リダイレクト。
- ruff / import 確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)