### PR TITLE
#40 箇条書き（ネスト階層）が描画されない不具合を修正

### DIFF
--- a/app/jinja.py
+++ b/app/jinja.py
@@ -6,7 +6,9 @@ Jinja2Templates のシングルトン（フィルター登録済み）
 import markdown as markdown_lib
 from fastapi.templating import Jinja2Templates
 
+from app.markdown_utils import normalize_markdown
+
 templates = Jinja2Templates(directory="app/templates")
 templates.env.filters["markdown"] = lambda text: markdown_lib.markdown(
-    text or "", extensions=["nl2br"], tab_length=2
+    normalize_markdown(text or ""), extensions=["nl2br"], tab_length=2
 )

--- a/app/markdown_utils.py
+++ b/app/markdown_utils.py
@@ -1,0 +1,71 @@
+"""
+Markdown 前処理ユーティリティ
+
+Python-Markdown は CommonMark と異なり、段落の直後（空行なし）に始まる
+箇条書き/番号付きリストをリストとして認識せず、段落の続きと見なす。
+LLM（要約・ダイジェスト）出力は「説明文。\\n- 箇条書き」のように空行なしで
+リストを続けることが多く、階層付きの箇条書きが <ul> にならず素の段落として
+描画される原因になっていた。
+
+normalize_markdown() はリスト開始行の直前に空行を補ってこれを解消する。
+リスト途中の項目や継続行を誤って分割しないよう、リスト状態を追跡する。
+fenced code block (``` / ~~~) の内部は対象外。
+"""
+
+from __future__ import annotations
+
+import re
+
+# 行頭（インデント可）の箇条書き/番号付きリスト項目: "- x" "* x" "+ x" "1. x"
+_LIST_ITEM_RE = re.compile(r"^[ \t]*(?:[-*+]|\d+\.)[ \t]+\S")
+# fenced code block の開始/終了フェンス
+_FENCE_RE = re.compile(r"^[ \t]*(?:```|~~~)")
+
+
+def normalize_markdown(text: str) -> str:
+    """段落の直後（空行なし）に始まるリストの前に空行を挿入して返す。"""
+    if not text or (
+        "-" not in text and "*" not in text and "+" not in text and "." not in text
+    ):
+        return text
+
+    lines = text.split("\n")
+    out: list[str] = []
+    in_fence = False
+    in_list = False
+    prev_blank = True  # 文頭は「空行の後」とみなす
+
+    for line in lines:
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            in_list = False
+            out.append(line)
+            prev_blank = False
+            continue
+
+        if in_fence:
+            out.append(line)
+            prev_blank = line.strip() == ""
+            continue
+
+        is_blank = line.strip() == ""
+        is_item = bool(_LIST_ITEM_RE.match(line))
+
+        if is_item:
+            # 段落 → リスト の遷移（リスト外 かつ 直前が非空）でのみ空行を補う
+            if not in_list and not prev_blank:
+                out.append("")
+            in_list = True
+        elif is_blank:
+            pass  # loose list の途中かもしれないのでリスト状態は維持
+        else:
+            # 非空・非リスト行
+            if in_list and not line[:1].isspace() and prev_blank:
+                # 空行を挟んだ非インデント段落 → リスト終了
+                in_list = False
+            # それ以外（インデント継続行・lazy 継続行）はリスト内のまま
+
+        out.append(line)
+        prev_blank = is_blank
+
+    return "\n".join(out)

--- a/app/routers/archive.py
+++ b/app/routers/archive.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.database import get_db
 from app.db.models import UserTag
 from app.jinja import templates
+from app.markdown_utils import normalize_markdown
 from app.schemas import ArticleItem
 from app.services.pipeline import load_daily_data, list_available_dates
 from app.services.theme_search import load_theme_collections_for_date
@@ -80,7 +81,7 @@ async def archive_day(
     if digest_raw:
         processed = inject_citations(digest_raw, date_str, is_archive=True)
         digest_html = md.markdown(
-            processed,
+            normalize_markdown(processed),
             extensions=["fenced_code", "tables", "nl2br"],
             tab_length=2,
         )

--- a/app/routers/summaries.py
+++ b/app/routers/summaries.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Request, HTTPException, Query
 from fastapi.responses import HTMLResponse
 
 from app.jinja import templates
+from app.markdown_utils import normalize_markdown
 from app.services.digest import load_digest, list_digests, inject_citations
 from app.schemas import DailySummaryMeta
 
@@ -58,7 +59,7 @@ async def summary_detail(request: Request, date_str: str):
 
     processed = inject_citations(content, date_str, is_archive=False)
     html_content = md.markdown(
-        processed,
+        normalize_markdown(processed),
         extensions=["fenced_code", "tables", "toc", "nl2br"],
         tab_length=2,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ dev = [
 [tool.mypy]
 ignore_missing_imports = true
 
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
 [tool.poe.tasks]
 format = "uv run ruff format ."
 lint = "uv run ruff check --fix ."

--- a/tests/test_markdown_utils.py
+++ b/tests/test_markdown_utils.py
@@ -1,0 +1,65 @@
+"""normalize_markdown の回帰テスト。
+
+段落直後に空行なしで始まるリストの前に空行を補い、Python-Markdown が
+リスト（ネスト含む）として描画できるようにする処理を検証する。
+"""
+
+import markdown as md
+
+from app.markdown_utils import normalize_markdown
+
+_EXT = ["fenced_code", "tables", "nl2br"]
+
+
+def _render(src: str) -> str:
+    return md.markdown(normalize_markdown(src), extensions=_EXT, tab_length=2)
+
+
+def test_paragraph_followed_by_list_becomes_list():
+    # 空行なしで段落→箇条書きが続くケース（実際の LLM 出力パターン）
+    src = "説明文。\n- 親A\n  - 子A1\n  - 子A2\n- 親B\n"
+    html = _render(src)
+    # 外側リスト + 親A 配下のネストリスト = <ul> 2、項目は 親A/子A1/子A2/親B = 4
+    assert html.count("<ul>") == 2
+    assert html.count("<li>") == 4
+    assert "<p>説明文。</p>" in html
+    # 親A の中に子リストがネストしている
+    assert "親A<ul>" in html
+
+
+def test_multiline_item_not_split():
+    # 項目の継続行（インデント）でリストが分割されないこと
+    src = "導入。\n- 親項目の1行目\n  同じ項目の続き\n- 次の親\n"
+    html = _render(src)
+    assert html.count("<ul>") == 1
+    assert html.count("<li>") == 2
+
+
+def test_fenced_code_block_untouched():
+    src = "前文。\n```\n- これはコード\n- リストではない\n```\n本文。\n- 本物のリスト\n"
+    html = _render(src)
+    # コードブロック内はリスト化されず、後続の本物のリストのみ <ul> 化
+    assert html.count("<ul>") == 1
+    assert "<code>" in html or "<pre>" in html
+
+
+def test_numbered_list():
+    src = "貢献は以下。\n1. 提案\n2. 達成\n"
+    html = _render(src)
+    assert html.count("<ol>") == 1
+    assert html.count("<li>") == 2
+
+
+def test_already_blank_line_not_doubled():
+    # すでに空行がある場合は二重に挿入しない
+    src = "段落。\n\n- 項目\n"
+    normalized = normalize_markdown(src)
+    assert "\n\n\n" not in normalized
+    assert _render(src).count("<ul>") == 1
+
+
+def test_empty_and_plain_text():
+    assert normalize_markdown("") == ""
+    assert normalize_markdown("ただの文章。改行のみ。\n次の行。") == (
+        "ただの文章。改行のみ。\n次の行。"
+    )


### PR DESCRIPTION
Closes #40

## 原因
Python-Markdown は CommonMark と異なり、**段落の直後（空行なし）に始まるリストをリストとして認識せず段落の続き**にする。LLM 出力（要約・ダイジェスト・チャット）は「説明文。⏎- 箇条書き」と空行なしで続けることが多く、箇条書き全体が `<p>` になり階層が一切描画されていなかった（実データで `<ul>×0` を確認）。マーカー `-`/`*` や `tab_length` は無関係。

## 修正
描画前に「段落→リストの境界に空行を補う」正規化を追加し、全描画箇所に適用。
- `app/markdown_utils.py`（新規）: `normalize_markdown()`。リスト状態を追跡し、**途中項目・継続行は分割しない / fenced code 内は不変 / 番号付きリスト対応**
- `app/jinja.py`（`markdown` フィルタ＝カード要約・チャット応答）、`app/routers/archive.py`・`summaries.py`（一面まとめ）に適用
- `nl2br` / `tab_length=2` は据え置き（空行さえあればネストは正しく描画される）

## 検証
- 実サマリー: `<ul>×0` → `<ul>×6 / <li>×11`、ネスト復活
- 実起動: `/archive/2026-06-10` で `<ul>×51`、`/summaries/2026-06-10` で `<ul>×6`
- ユニットテスト6件追加（`tests/test_markdown_utils.py`）＋ pytest 設定。`poe check` 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)