### PR TITLE
フッターに現在使用中の Gemini モデル名を表示

### DIFF
--- a/app/jinja.py
+++ b/app/jinja.py
@@ -6,9 +6,15 @@ Jinja2Templates のシングルトン（フィルター登録済み）
 import markdown as markdown_lib
 from fastapi.templating import Jinja2Templates
 
+from app.config import settings
 from app.markdown_utils import normalize_markdown
 
 templates = Jinja2Templates(directory="app/templates")
 templates.env.filters["markdown"] = lambda text: markdown_lib.markdown(
     normalize_markdown(text or ""), extensions=["nl2br"], tab_length=2
 )
+
+# 全テンプレートで参照できるグローバル（フッターのモデル名表示等）。
+# 機密値（API キー等）は渡さず、現在使用中の Gemini モデル名のみ公開する。
+templates.env.globals["gemini_summary_model"] = settings.gemini_summary_model
+templates.env.globals["gemini_chat_model"] = settings.gemini_chat_model

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -183,6 +183,14 @@
       <div class="text-center space-y-1">
         <p class="text-slate-400 text-xs font-medium tracking-wide uppercase">AI Daily Survey</p>
         <p class="text-slate-400 text-xs">毎日 正午 (JST) 自動更新</p>
+        <p class="text-slate-400 text-[11px]">
+          <span class="text-slate-400">Gemini モデル:</span>
+          要約・チャット
+          <code class="px-1 py-0.5 bg-slate-100 rounded text-slate-500">{{ gemini_chat_model }}</code>
+          <span class="mx-0.5 text-slate-300">·</span>
+          一面まとめ
+          <code class="px-1 py-0.5 bg-slate-100 rounded text-slate-500">{{ gemini_summary_model }}</code>
+        </p>
       </div>
     </footer>
   </div>


### PR DESCRIPTION
## 概要
全ページ共通のフッターに、現在使用中の Gemini モデル名を表示する。

```
Gemini モデル: 要約・チャット  gemini-3.1-flash-lite  ·  一面まとめ  gemini-3-flash-preview
```

## 変更点
- `app/templates/base.html`: フッターにモデル名の表示行を追加
- `app/jinja.py`: `gemini_chat_model` / `gemini_summary_model` を Jinja グローバルに登録（**API キー等の機密値は出さず、モデル名のみ**公開）
- 値は `settings`（環境変数）由来のため、`.env` のモデル変更に自動追従する

## 検証
- ローカル起動でフッター表示を確認（`gemini-3.1-flash-lite` / `gemini-3-flash-preview`、HTTP 200）
- `poe check`（ruff/mypy 40ファイル）・`pytest` 9件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)