### PR TITLE
#30 ref リンクのスクロールを GitHub Trending のソートタブ重複IDに対応

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -455,9 +455,42 @@
 <!-- アンカーリンク処理: #article-xxx クリック時にトグルを開いてスムーズスクロール -->
 <script>
 (function () {
+  // ソートタブ（x-show="sort==='xxx'"）内の要素なら該当タブに切り替える
+  function activateSortTab(el) {
+    var sortTab = el.closest('[x-show^="sort==="]');
+    if (!sortTab || !window.Alpine) return;
+    var m = sortTab.getAttribute('x-show').match(/sort==='(\w+)'/);
+    if (!m) return;
+    var section = sortTab.closest('[x-data]');
+    if (section) {
+      try { Alpine.$data(section).sort = m[1]; } catch (e) {}
+    }
+  }
+
+  // ID重複対応: 同一IDが複数ある場合（GitHub Trending の各ソートタブなど）
+  // ソートタブ外 → 現在アクティブなソートタブ内 → 最初の候補の順で選択
+  function findBestTarget(hash) {
+    var id = hash.replace('#', '');
+    var candidates = document.querySelectorAll('[id="' + CSS.escape(id) + '"]');
+    if (candidates.length === 0) return null;
+    if (candidates.length === 1) return candidates[0];
+
+    // ソートタブ外の候補を優先
+    for (var i = 0; i < candidates.length; i++) {
+      if (!candidates[i].closest('[x-show^="sort==="]')) return candidates[i];
+    }
+    // 現在アクティブなソートタブ内の候補を優先
+    for (var i = 0; i < candidates.length; i++) {
+      var tab = candidates[i].closest('[x-show^="sort==="]');
+      if (tab && tab.style.display !== 'none') return candidates[i];
+    }
+    // どれも非表示なら最初の候補（ソートタブを切り替えて表示する）
+    return candidates[0];
+  }
+
   function openAndScrollTo(hash) {
     if (!hash || !hash.startsWith('#article-')) return;
-    var target = document.querySelector(hash);
+    var target = findBestTarget(hash);
     if (!target) return;
 
     // 祖先の Alpine x-data で open プロパティを持つ要素を収集（内→外）
@@ -479,6 +512,9 @@
     ancestors.slice().reverse().forEach(function (anc) {
       try { Alpine.$data(anc).open = true; } catch (e) {}
     });
+
+    // ソートタブ切り替え（GitHub Trending の Daily/Weekly/Monthly/Total）
+    activateSortTab(target);
 
     // スクロールオフセット: ナビ高さ + 記事が属するセクション階層のスティッキーバー高さ
     // （例: AI企業動向 + 自社発表 の2段が表示される場合はその合計）


### PR DESCRIPTION
## 概要
一面まとめ・テーマ別論文総括などの引用リンク `[↗]`（`#article-{safe_id}`）から GitHub Trending のカードへ飛ぶ際、同じリポジトリが Daily/Weekly/Monthly/Total の複数ソートタブに重複表示されることで **同一 ID が複数存在し**、`document.querySelector` が**非表示タブ内の要素**を拾って誤スクロールする問題を修正。

## 変更点（`app/templates/base.html`）
- `findBestTarget(hash)`: 同一 ID が複数ある場合、**ソートタブ外 → 現在アクティブなタブ内 → 先頭** の順で最適な要素を選択
- `activateSortTab(target)`: 対象がソートタブ内なら **該当タブに切り替えてから** スクロール
- `document.querySelector(hash)` → `findBestTarget(hash)` に置換

## 背景
`feature/fix-ref-scroll` ブランチに、この対応を含む版（`7445f48`）が**未マージ**で残っていた（develop には小さい初期版 `3bf2823`=`waitAndScroll` のみが PR #31 で取り込み済み）。古い起点（`c049e74`）からの生 merge は base.html が大量コンフリクトするため、**差分のみを現行 develop へクリーンに再適用**した。適用後のスクロール JS は `7445f48` と同等。

## 検証
- ローカル起動で `/archive/...` が HTTP 200、配信 HTML に新 JS（`findBestTarget`/`activateSortTab`）が含まれることを確認
- GitHub Trending セクションの `x-data="{...sort:'daily'...}"` / `x-show="sort==='...'"` 構造と整合
> JS の対話挙動（タブ切替＋スクロール）の最終確認はブラウザ操作が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)